### PR TITLE
Changing Release build to use /MT instead of /MD

### DIFF
--- a/SimpleGraphic.vcxproj
+++ b/SimpleGraphic.vcxproj
@@ -136,6 +136,7 @@
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)engine;$(SolutionDir)vcpkg\installed\x86-windows-static\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
This is an attempt to remove the dependency on the Visual Studio 2019 redistributable.