### PR TITLE
Invalidate the entire client area for the console edit control after creating it

### DIFF
--- a/engine/system/win/sys_console.cpp
+++ b/engine/system/win/sys_console.cpp
@@ -130,6 +130,7 @@ void sys_console_c::ThreadProc()
 
 	// Create the output window background brush
 	bBackground = CreateSolidBrush(CFG_SCON_TEXTBG);
+	InvalidateRect(hwOut, nullptr, TRUE);
 
 	// Flush any messages created
 	sys->RunMessages();


### PR DESCRIPTION
This causes the background to clear to the proper background color immediately.

The new PathOfBuilding.exe launcher requires this change or the console window will appear white where text has not been written to it.