### PR TITLE
Assume clipboard text from PoB is UTF-8 or ASCII

### DIFF
--- a/engine/system/win/sys_main.cpp
+++ b/engine/system/win/sys_main.cpp
@@ -385,14 +385,15 @@ void sys_main_c::ShowCursor(int doShow)
 void sys_main_c::ClipboardCopy(const char* str)
 {
 	size_t len = strlen(str);
-	HGLOBAL hg = GlobalAlloc(GMEM_MOVEABLE, len + 1);
+	auto cch = MultiByteToWideChar(CP_UTF8, 0, str, len + 1, nullptr, 0);
+	HGLOBAL hg = GlobalAlloc(GMEM_MOVEABLE, cch * sizeof(wchar_t));
 	if ( !hg ) return;
-	char* cp = (char*)GlobalLock(hg);
-	strcpy(cp, str);
+	wchar_t* cp = (wchar_t*)GlobalLock(hg); // 8-byte aligned so cast is safe
+	MultiByteToWideChar(CP_UTF8, 0, str, len + 1, cp, cch);
 	GlobalUnlock(hg);
 	OpenClipboard((HWND)video->GetWindowHandle());
 	EmptyClipboard();
-	SetClipboardData(CF_TEXT, hg);
+	SetClipboardData(CF_UNICODETEXT, hg);
 	CloseClipboard();
 }
 


### PR DESCRIPTION
The Copy function previously put the copied text from Lua verbatim on the clipboard as `CF_TEXT` which if not annotated with a locale is assumed to be in the current "input locale".
This commit changes it to instead assume that it's either in UTF-8 (or ASCII, which is a subset of UTF-8), transcoding it to UTF-16LE for `CF_UNICODETEXT`.
This enables the ability for the Lua side to copy out UTF-8 text which it may have obtained from an external source like trade or another API.
A brief audit of the current Lua source code does not reveal any call site that should contain text in the local codepage as build XML is supposed to be UTF-8 and no file paths seem to be copied.