### PR TITLE
Add key event support for VK_ADD, VK_SUBTRACT, VK_NUMPAD0

### DIFF
--- a/engine/system/win/sys_main.cpp
+++ b/engine/system/win/sys_main.cpp
@@ -244,7 +244,7 @@ static const byte sys_keyRemap[] = {
 	0,				// 5D		VK_APPS
 	0,				// 5E		-
 	0,				// 5F		VK_SLEEP
-	0,				// 60		VK_NUMPAD0
+	'0',			// 60		VK_NUMPAD0
 	0,				// 61		VK_NUMPAD1
 	0,				// 62		VK_NUMPAD2
 	0,				// 63		VK_NUMPAD3

--- a/engine/system/win/sys_main.cpp
+++ b/engine/system/win/sys_main.cpp
@@ -255,9 +255,9 @@ static const byte sys_keyRemap[] = {
 	0,				// 68		VK_NUMPAD8
 	0,				// 69		VK_NUMPAD9
 	0,				// 6A		VK_MULTIPLY
-	0,				// 6B		VK_ADD
+	'+',			// 6B		VK_ADD
 	0,				// 6C		VK_SEPARATOR
-	0,				// 6D		VK_SUBTRACT
+	'-',			// 6D		VK_SUBTRACT
 	0,				// 6E		VK_DECIMAL
 	0,				// 6F		VK_DIVIDE
 	KEY_F1,			// 70		VK_F1


### PR DESCRIPTION
This adds support to catch the `+`, `-` and `0` characters from the numpad. This allows me to catch them as keye events for this feature: 
https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4355

I think a lot of people expect those keys to work for zooming functionality, thus this PR.
Similar functionality can be tested i.e. in Chrome for zooming in / out and resetting.