### PR TITLE
Close errored console on pressing X

### DIFF
--- a/engine/system/win/sys_console.cpp
+++ b/engine/system/win/sys_console.cpp
@@ -157,6 +157,9 @@ void sys_console_c::ThreadProc()
 	UnregisterClass(CFG_SCON_TITLE " Class", sys->hinst);
 
 	isRunning = false;
+
+	// Flush windowless messages (Like WM_QUIT)
+	sys->RunMessages();
 }
 
 sys_console_c::~sys_console_c()
@@ -187,6 +190,7 @@ LRESULT __stdcall sys_console_c::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPA
 		}
 	case WM_CLOSE:
 		// Quit
+		conWin->doRun = false;
 		PostQuitMessage(0);
 		return FALSE;
 	}


### PR DESCRIPTION
If the console errored out, pressing X would do nothing.  Easy way to test this was to run a second instance of PoB when the debug code was listening on a port:
```lua
local dbg = require('emmy_core')
dbg.tcpListen('localhost', 9966)
```