### PR TITLE
Fix Lua library loading from system environment variable

### DIFF
--- a/ui_subscript.cpp
+++ b/ui_subscript.cpp
@@ -339,6 +339,10 @@ bool ui_subscript_c::Start()
 	lua_pushlightuserdata(L, this);
 	lua_rawseti(L, LUA_REGISTRYINDEX, 0);
 	lua_pushcfunction(L, traceback);
+
+	lua_pushboolean(L, 1);
+	lua_setfield(L, LUA_REGISTRYINDEX, "LUA_NOENV");
+
 	// Add libraries and APIs
 	lua_gc(L, LUA_GCSTOP, 0);
 	luaL_openlibs(L);


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5916

The reason people were able to get around this issue on the dev branch was because while we didn't load environment variables when starting PoB, we'd still load them when running subscripts.  In this case, the UpdateCheck was still loading the wrong Lua version from Scoop.