### PR TITLE
Misc. macOS portability fixes

### DIFF
--- a/engine/render/r_font.cpp
+++ b/engine/render/r_font.cpp
@@ -44,7 +44,7 @@ r_font_c::r_font_c(r_renderer_c* renderer, const char* fontName)
 	numFontHeight = 0;
 	fontHeightMap = NULL;
 
-	std::string fileNameBase = fmt::format(CFG_DATAPATH "fonts/{}", fontName);
+	std::string fileNameBase = fmt::format(CFG_DATAPATH "Fonts/{}", fontName);
 
 	// Open info file
 	std::string tgfName = fileNameBase + ".tgf";

--- a/engine/render/r_main.cpp
+++ b/engine/render/r_main.cpp
@@ -9,6 +9,7 @@
 #include "r_local.h"
 
 #include <array>
+#include <filesystem>
 #include <fmt/chrono.h>
 #include <map>
 #include <numeric>
@@ -1295,7 +1296,9 @@ void r_renderer_c::EndFrame()
 		for (int l = 0; l < numLayer; l++) {
 			auto& layer = layerSort[l];
 			if (layerBreak && layerBreak->first == layer->layer && layerBreak->second == layer->subLayer) {
+#ifdef _WIN32
 				DebugBreak();
+#endif
 			}
 			layer->Render();
 		}
@@ -1711,7 +1714,7 @@ void r_renderer_c::DoScreenshot(image_c* i, const char* ext)
 	// curTimeSt.tm_hour, curTimeSt.tm_min, curTimeSt.tm_sec, ext);
 
 	// Make folder if it doesn't exist
-	_mkdir(CFG_DATAPATH "Screenshots");
+	std::filesystem::create_directory(CFG_DATAPATH "Screenshots");
 	
 	// Save image
 	if (i->Save(ssname.c_str())) {

--- a/engine/render/r_main.h
+++ b/engine/render/r_main.h
@@ -12,6 +12,7 @@
 
 #include <array>
 #include <imgui.h>
+#include <vector>
 
 // =======
 // Classes

--- a/libs/LZip/lzip.cpp
+++ b/libs/LZip/lzip.cpp
@@ -1,9 +1,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <io.h>
 
 #include "zlib.h"
+
+#ifdef _WIN32
+#define LZIP_EXPORT __declspec(dllexport)
+#else
+#define LZIP_EXPORT
+#endif
 
 extern "C" {
 #include "lua.h"
@@ -326,7 +331,7 @@ void fs_file_c::Seek(int pos, int mode)
 			// Seek forward
 			byte* sk = new byte[diff];
 			Read(sk, diff);
-			delete sk;
+			delete[] sk;
 		} else if (diff < 0) {
 			// Restart reading
 			pU = 0;
@@ -337,7 +342,7 @@ void fs_file_c::Seek(int pos, int mode)
 				// Seek forward
 				byte* sk = new byte[seekto];
 				Read(sk, seekto);
-				delete sk;
+				delete[] sk;
 			}
 		}
 	} else {
@@ -668,7 +673,7 @@ static int l_zipFile_Length(lua_State* L)
 	return 1;
 }
 
-extern "C" __declspec(dllexport) int luaopen_lzip(lua_State* L)
+extern "C" LZIP_EXPORT int luaopen_lzip(lua_State* L)
 {
 	lua_settop(L, 0);
 	lua_newtable(L); // Library table

--- a/ui_main.cpp
+++ b/ui_main.cpp
@@ -286,8 +286,11 @@ void ui_main_c::ScriptInit()
 	lua_pushcfunction(L, traceback);
 	lua_pushvalue(L, -1);
 	lua_setfield(L, LUA_REGISTRYINDEX, "traceback");
+
+#if _WIN32
 	lua_pushboolean(L, 1);
 	lua_setfield(L, LUA_REGISTRYINDEX, "LUA_NOENV");
+#endif
 
 	// Add libraries and APIs
 	lua_gc(L, LUA_GCSTOP, 0);

--- a/ui_subscript.cpp
+++ b/ui_subscript.cpp
@@ -314,8 +314,10 @@ bool ui_subscript_c::Start()
 	lua_rawseti(L, LUA_REGISTRYINDEX, 0);
 	lua_pushcfunction(L, traceback);
 
+#ifdef _WIN32
 	lua_pushboolean(L, 1);
 	lua_setfield(L, LUA_REGISTRYINDEX, "LUA_NOENV");
+#endif
 
 	// Add libraries and APIs
 	lua_gc(L, LUA_GCSTOP, 0);
@@ -446,6 +448,7 @@ void ui_subscript_c::SubScriptFrame()
 				ui->PCall(extraArgs + 2, 0);
 			}
 			FreeString(errorStr);
+			errorStr = nullptr;
 		} else {
 			int extraArgs = ui->PushCallback("OnSubFinished");
 			if (extraArgs >= 0) {


### PR DESCRIPTION
This set of changes makes the project build on macOS and addresses `new[]`/`delete` mismatches in LZip and fixes a double-free crash in subscripts when they encounter a fatal error, like when failing to load `lcurl.safe`.