### PR TITLE
Fix window positioning and maximization logic

### DIFF
--- a/engine/core/core_video.cpp
+++ b/engine/core/core_video.cpp
@@ -46,7 +46,6 @@ public:
 	sys_IMain* sys;
 
 	conVar_c* vid_mode;
-	conVar_c* vid_display;
 	conVar_c* vid_fullscreen;
 	conVar_c* vid_resizable;
 	conVar_c* vid_last;
@@ -69,7 +68,6 @@ core_video_c::core_video_c(sys_IMain* sysHnd)
 	: conCmdHandler_c(sysHnd->con), sys(sysHnd)
 {
 	vid_mode		= sys->con->Cvar_Add("vid_mode", CV_ARCHIVE|CV_CLAMP, CFG_VID_DEFMODE, -1, VID_NUMMODES-1);
-	vid_display		= sys->con->Cvar_Add("vid_display", CV_ARCHIVE|CV_CLAMP, CFG_VID_DEFDISPLAY, -1, 15);
 	vid_fullscreen	= sys->con->Cvar_Add("vid_fullscreen", CV_ARCHIVE, CFG_VID_DEFFULLSCREEN);
 	vid_resizable	= sys->con->Cvar_Add("vid_resizable", CV_ARCHIVE|CV_CLAMP, CFG_VID_DEFRESIZABLE, 0, 3);
 	vid_last		= sys->con->Cvar_Add("vid_last", CV_ARCHIVE, "");
@@ -100,7 +98,6 @@ void core_video_c::Apply(bool shown)
 			}
 		}
 	}
-	set.display = vid_display->intVal;
 	if (vid_mode->intVal >= 0) {
 		set.mode[0] = (std::max)(vid_modeList[vid_mode->intVal][0], CFG_VID_MINWIDTH);
 		set.mode[1] = (std::max)(vid_modeList[vid_mode->intVal][1], CFG_VID_MINHEIGHT);
@@ -108,7 +105,6 @@ void core_video_c::Apply(bool shown)
 		set.mode[0] = 0;
 		set.mode[1] = 0;
 	}
-	set.depth = 0;
 	set.minSize[0] = CFG_VID_MINWIDTH;
 	set.minSize[1] = CFG_VID_MINHEIGHT;
 	sys->video->Apply(&set);

--- a/engine/system/sys_video.h
+++ b/engine/system/sys_video.h
@@ -10,7 +10,6 @@
 
 // Video settings flags
 enum vidFlags_e {
-	VID_TOPMOST = 0x02,
 	VID_RESIZABLE = 0x04,
 	VID_MAXIMIZE = 0x08,
 	VID_USESAVED = 0x10,
@@ -29,9 +28,7 @@ struct sys_vidSave_s {
 struct sys_vidSet_s {
 	bool	shown = false;		// Show window?
 	int		flags = 0;		// Flags
-	int		display = 0;	// Display number
-	int		mode[2] = {};	// Resolution or window size
-	int		depth = 0;		// Bit depth
+	int		mode[2] = {};	// Window size
 	int		minSize[2] = {};	// Minimum size for resizable windows
 	sys_vidSave_s save; // Saved state
 };


### PR DESCRIPTION
The code to restore the window position and size from saved data did not handle the case of being maximized on a non-primary monitor, nor did it adjust the window position when the stored location was completely outside of all active monitors.

This change addresses both these problems and removes some vestigal code around display affinity and always-on-top logic which we don't use.