### PR TITLE
Add renderer feature flag for Lua DPI awareness

### DIFF
--- a/engine/render.h
+++ b/engine/render.h
@@ -8,6 +8,11 @@
 // Classes
 // =======
 
+// Renderer feature flags
+enum r_featureFlag_e {
+	F_DPI_AWARE = 0x1, // App understands DPI, do not virtualize screen size/positions
+};
+
 // Font alignment
 enum r_fontAlign_e {
 	F_LEFT,
@@ -59,7 +64,7 @@ public:
 	static r_IRenderer* GetHandle(sys_IMain* sysHnd);
 	static void FreeHandle(r_IRenderer* hnd);
 
-	virtual void	Init() = 0;
+	virtual void	Init(r_featureFlag_e features) = 0;
 	virtual void	Shutdown() = 0;
 
 	virtual void	BeginFrame() = 0;

--- a/engine/render/r_main.cpp
+++ b/engine/render/r_main.cpp
@@ -823,9 +823,11 @@ void main(void) {
 // Init/Shutdown
 // =============
 
-void r_renderer_c::Init()
+void r_renderer_c::Init(r_featureFlag_e features)
 {
 	sys->con->PrintFunc("Render Init");
+
+	apiDpiAware = !!(features & F_DPI_AWARE);
 
 	timer_c timer;
 	timer.Start();
@@ -1637,15 +1639,24 @@ int r_renderer_c::VirtualScreenHeight() {
 }
 
 float r_renderer_c::VirtualScreenScaleFactor() {
-	return sys->video->vid.dpiScale;
+	if (apiDpiAware) {
+		return sys->video->vid.dpiScale;
+	}
+	return 1.0f;
 }
 
 int r_renderer_c::VirtualMap(int properValue) {
-	return (int)(properValue / VirtualScreenScaleFactor());
+	if (apiDpiAware) {
+		return properValue;
+	}
+	return (int)(properValue / sys->video->vid.dpiScale);
 }
 
 int r_renderer_c::VirtualUnmap(int mappedValue) {
-	return (int)(mappedValue * VirtualScreenScaleFactor());
+	if (apiDpiAware) {
+		return mappedValue;
+	}
+	return (int)(mappedValue * sys->video->vid.dpiScale);
 }
 
 // =====

--- a/engine/render/r_main.h
+++ b/engine/render/r_main.h
@@ -57,7 +57,7 @@ private:
 class r_renderer_c: public r_IRenderer, public conCmdHandler_c {
 public:
 	// Interface
-	void	Init();
+	void	Init(r_featureFlag_e features);
 	void	Shutdown();
 
 	void	BeginFrame();
@@ -159,6 +159,7 @@ public:
 		GLuint  blitSampleLocColour = 0;
 	};
 
+	bool apiDpiAware{};
 	RenderTarget rttMain;
 
 	std::vector<uint8_t> lastFrameHash{};

--- a/ui_main.cpp
+++ b/ui_main.cpp
@@ -237,7 +237,7 @@ void ui_main_c::Init(int argc, char** argv)
 	}
 }
 
-void ui_main_c::RenderInit()
+void ui_main_c::RenderInit(r_featureFlag_e features)
 {
 	if (renderer) {
 		return;
@@ -252,7 +252,7 @@ void ui_main_c::RenderInit()
 
 	// Initialise renderer
 	renderer = r_IRenderer::GetHandle(sys);
-	renderer->Init();
+	renderer->Init(features);
 
 	// Create UI console handler
 	conUI = ui_IConsole::GetHandle(this);

--- a/ui_main.h
+++ b/ui_main.h
@@ -49,7 +49,7 @@ public:
 
 	static int InitAPI(lua_State* L);
 
-	void	RenderInit();
+	void	RenderInit(r_featureFlag_e features);
 	void	ScriptInit();
 	void	ScriptShutdown();
 


### PR DESCRIPTION
The runtime is aware of the operating system display scaling factor and presents a virtual coordinate space for the Lua application where it scales the sizes and positions of the window and cursor without allowing the application any choice. This is a hack as scaling up the window contents by the desired amount leads to a low quality image.

In order to draw at true resolution the Lua program needs to both be able to tell what the scaling factor is to adjust all UI dimensions, but also able indicate to the runtime that it wishes to be free of the virtualization and instead use the real coordinate system.

As it's a very big task both in time and design-wise to make the UI scale the runtime needs to be able either launch in legacy mode but also in a mode with true visuals.

This is achieved here by making `RenderInit` take a sequence of feature flags as it's called from `Launch.lua`. This is early enough that most of the Lua application has yet to run and thus gets the chance to fetch the proper values as it starts up while the runtime also gets this request early enough to influence the initialization of the renderer and allocation of resources.

This change introduces a flag string of `"DPI_AWARE"` that instructs the runtime to go into a mode where it reports the true scale factor in `GetScreenScale`, provides a full-resolution render target and doesn't rescale the screen size or mouse positions anymore.

For alternative runtimes like `pobfrontend` any flags are ignored and their runtime continue to work as they always have, or can start honoring the flag if it fits their environment.