### PR TITLE
Evolve renderer backend and API surface

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "dep/imgui"]
 	path = dep/imgui
 	url = https://github.com/ocornut/imgui.git
+[submodule "dep/glm"]
+	path = dep/glm
+	url = https://github.com/g-truc/glm.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include(${PROJECT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake)
 
 set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION ".")
 include(InstallRequiredSystemLibraries)
+add_subdirectory(dep/glm)
 
 set(SIMPLEGRAPHIC_SOURCES
     "config.h"
@@ -25,6 +26,7 @@ set(SIMPLEGRAPHIC_SOURCES
     "dep/stb/stb_image_resize.h"
     "dep/stb/stb_image_write.h"
     "engine/common/common.cpp"
+    "engine/common.h"
     "engine/common/console.cpp"
     "engine/common/console.h"
     "engine/common/keylist.h"
@@ -137,6 +139,7 @@ target_compile_definitions(imgui PUBLIC
 target_include_directories(imgui PUBLIC
     dep/imgui
     dep/imgui/backends
+    dep/imgui/misc/cpp
 )
 
 target_link_libraries(imgui PUBLIC
@@ -181,6 +184,7 @@ target_link_libraries(SimpleGraphic
     unofficial::angle::libGLESv2
     fmt::fmt
     glfw
+    glm::glm
     imgui
     LuaJIT::LuaJIT
     re2::re2

--- a/engine/core/core_video.cpp
+++ b/engine/core/core_video.cpp
@@ -46,7 +46,6 @@ public:
 	sys_IMain* sys;
 
 	conVar_c* vid_mode;
-	conVar_c* vid_display;
 	conVar_c* vid_fullscreen;
 	conVar_c* vid_resizable;
 	conVar_c* vid_last;
@@ -69,7 +68,6 @@ core_video_c::core_video_c(sys_IMain* sysHnd)
 	: conCmdHandler_c(sysHnd->con), sys(sysHnd)
 {
 	vid_mode		= sys->con->Cvar_Add("vid_mode", CV_ARCHIVE|CV_CLAMP, CFG_VID_DEFMODE, -1, VID_NUMMODES-1);
-	vid_display		= sys->con->Cvar_Add("vid_display", CV_ARCHIVE|CV_CLAMP, CFG_VID_DEFDISPLAY, -1, 15);
 	vid_fullscreen	= sys->con->Cvar_Add("vid_fullscreen", CV_ARCHIVE, CFG_VID_DEFFULLSCREEN);
 	vid_resizable	= sys->con->Cvar_Add("vid_resizable", CV_ARCHIVE|CV_CLAMP, CFG_VID_DEFRESIZABLE, 0, 3);
 	vid_last		= sys->con->Cvar_Add("vid_last", CV_ARCHIVE, "");
@@ -100,7 +98,6 @@ void core_video_c::Apply(bool shown)
 			}
 		}
 	}
-	set.display = vid_display->intVal;
 	if (vid_mode->intVal >= 0) {
 		set.mode[0] = (std::max)(vid_modeList[vid_mode->intVal][0], CFG_VID_MINWIDTH);
 		set.mode[1] = (std::max)(vid_modeList[vid_mode->intVal][1], CFG_VID_MINHEIGHT);
@@ -108,7 +105,6 @@ void core_video_c::Apply(bool shown)
 		set.mode[0] = 0;
 		set.mode[1] = 0;
 	}
-	set.depth = 0;
 	set.minSize[0] = CFG_VID_MINWIDTH;
 	set.minSize[1] = CFG_VID_MINHEIGHT;
 	sys->video->Apply(&set);

--- a/engine/render.h
+++ b/engine/render.h
@@ -8,6 +8,11 @@
 // Classes
 // =======
 
+// Renderer feature flags
+enum r_featureFlag_e {
+	F_DPI_AWARE = 0x1, // App understands DPI, do not virtualize screen size/positions
+};
+
 // Font alignment
 enum r_fontAlign_e {
 	F_LEFT,
@@ -59,7 +64,7 @@ public:
 	static r_IRenderer* GetHandle(sys_IMain* sysHnd);
 	static void FreeHandle(r_IRenderer* hnd);
 
-	virtual void	Init() = 0;
+	virtual void	Init(r_featureFlag_e features) = 0;
 	virtual void	Shutdown() = 0;
 
 	virtual void	BeginFrame() = 0;

--- a/engine/render/r_font.cpp
+++ b/engine/render/r_font.cpp
@@ -17,10 +17,10 @@
 
 // Glyph parameters
 struct f_glyph_s {
-	double	tcLeft = 0.0;
-	double	tcRight = 0.0;
-	double	tcTop = 0.0;
-	double	tcBottom = 0.0;
+	float	tcLeft = 0.0;
+	float	tcRight = 0.0;
+	float	tcTop = 0.0;
+	float	tcBottom = 0.0;
 	int		width = 0;
 	int		spLeft = 0;
 	int		spRight = 0;
@@ -32,7 +32,7 @@ struct f_fontHeight_s {
 	int		height;
 	int		numGlyph;
 	f_glyph_s glyphs[128];
-	f_glyph_s defGlyph{0.0, 0.0, 0.0, 0.0, 0, 0, 0};
+	f_glyph_s defGlyph{0.0f, 0.0f, 0.0f, 0.0f, 0, 0, 0};
 
 	f_glyph_s const& Glyph(char ch) const {
 		if ((unsigned char)ch >= numGlyph) {
@@ -84,10 +84,10 @@ r_font_c::r_font_c(r_renderer_c* renderer, const char* fontName)
 			// Add glyph
 			if (fh->numGlyph >= 128) continue;
 			f_glyph_s* glyph = &fh->glyphs[fh->numGlyph++];
-			glyph->tcLeft = (double)x / fh->tex->fileWidth;
-			glyph->tcRight = (double)(x + w) / fh->tex->fileWidth;
-			glyph->tcTop = (double)y / fh->tex->fileHeight;
-			glyph->tcBottom = (double)(y + fh->height) / fh->tex->fileHeight;
+			glyph->tcLeft = (float)x / fh->tex->fileWidth;
+			glyph->tcRight = (float)(x + w) / fh->tex->fileWidth;
+			glyph->tcTop = (float)y / fh->tex->fileHeight;
+			glyph->tcBottom = (float)(y + fh->height) / fh->tex->fileHeight;
 			glyph->width = w;
 			glyph->spLeft = sl;
 			glyph->spRight = sr;
@@ -240,14 +240,14 @@ void r_font_c::DrawTextLine(scp_t pos, int align, int height, col4_t col, const 
 
 	// Find best height to use
 	f_fontHeight_s *fh = fontHeights[height > maxHeight? (numFontHeight - 1) : fontHeightMap[height]];
-	double scale = (double)height / fh->height;
+	float scale = (float)height / fh->height;
 
 	// Calculate the string position
-	double x = pos[X];
-	double y = pos[Y];
+	float x = pos[X];
+	float y = pos[Y];
 	if (align != F_LEFT) {
 		// Calculate the real width of the string
-		double width = StringWidthInternal(fh, str) * scale;
+		float width = StringWidthInternal(fh, str) * scale;
 		switch (align) {
 		case F_CENTRE:
 			x = floor((renderer->VirtualScreenWidth() - width) / 2.0f + pos[X]);
@@ -297,7 +297,7 @@ void r_font_c::DrawTextLine(scp_t pos, int align, int height, col4_t col, const 
 		auto& glyph = fh->Glyph(*str++);
 		x+= glyph.spLeft * scale;
 		if (glyph.width) {
-			double w = glyph.width * scale;
+			float w = glyph.width * scale;
 			if (x + w >= 0 && x < renderer->VirtualScreenWidth()) {
 				renderer->curLayer->Quad(
 					glyph.tcLeft, glyph.tcTop, x, y,

--- a/engine/render/r_main.cpp
+++ b/engine/render/r_main.cpp
@@ -870,9 +870,11 @@ void main(void) {
 // Init/Shutdown
 // =============
 
-void r_renderer_c::Init()
+void r_renderer_c::Init(r_featureFlag_e features)
 {
 	sys->con->PrintFunc("Render Init");
+
+	apiDpiAware = !!(features & F_DPI_AWARE);
 
 	timer_c timer;
 	timer.Start();
@@ -1776,15 +1778,24 @@ int r_renderer_c::VirtualScreenHeight() {
 }
 
 float r_renderer_c::VirtualScreenScaleFactor() {
-	return sys->video->vid.dpiScale;
+	if (apiDpiAware) {
+		return sys->video->vid.dpiScale;
+	}
+	return 1.0f;
 }
 
 int r_renderer_c::VirtualMap(int properValue) {
-	return (int)(properValue / VirtualScreenScaleFactor());
+	if (apiDpiAware) {
+		return properValue;
+	}
+	return (int)(properValue / sys->video->vid.dpiScale);
 }
 
 int r_renderer_c::VirtualUnmap(int mappedValue) {
-	return (int)(mappedValue * VirtualScreenScaleFactor());
+	if (apiDpiAware) {
+		return mappedValue;
+	}
+	return (int)(mappedValue * sys->video->vid.dpiScale);
 }
 
 // =====

--- a/engine/render/r_main.cpp
+++ b/engine/render/r_main.cpp
@@ -1904,9 +1904,10 @@ r_renderer_c::RenderTarget& r_renderer_c::GetPresentRenderTarget()
 	return rttMain[presentRtt];
 }
 
-// ============================================
-// MurmurHash implementation from public domain
-// ============================================
+// ===========================================================
+// MurmurHash implementation from public domain, obtained from
+// https://github.com/explosion/murmurhash/blob/9281c4825c24e64476457db89fb1d39bf09b3d23/murmurhash/MurmurHash2.cpp
+// ===========================================================
 
 #if _WIN32
 #define BIG_CONSTANT(x) (x)

--- a/engine/render/r_main.h
+++ b/engine/render/r_main.h
@@ -205,4 +205,7 @@ public:
 	void	DoScreenshot(image_c* i, const char* ext);
 
 	void	C_Screenshot(IConsole* conHnd, args_c &args);
+
+	RenderTarget& GetDrawRenderTarget();
+	RenderTarget& GetPresentRenderTarget();
 };

--- a/engine/render/r_main.h
+++ b/engine/render/r_main.h
@@ -67,7 +67,7 @@ private:
 class r_renderer_c: public r_IRenderer, public conCmdHandler_c {
 public:
 	// Interface
-	void	Init();
+	void	Init(r_featureFlag_e features);
 	void	Shutdown();
 
 	void	BeginFrame();
@@ -169,6 +169,7 @@ public:
 		GLuint  blitSampleLocColour = 0;
 	};
 
+	bool apiDpiAware{};
 	RenderTarget rttMain[2];
 	int	presentRtt = 0;
 

--- a/engine/system/sys_video.h
+++ b/engine/system/sys_video.h
@@ -10,7 +10,6 @@
 
 // Video settings flags
 enum vidFlags_e {
-	VID_TOPMOST = 0x02,
 	VID_RESIZABLE = 0x04,
 	VID_MAXIMIZE = 0x08,
 	VID_USESAVED = 0x10,
@@ -29,9 +28,7 @@ struct sys_vidSave_s {
 struct sys_vidSet_s {
 	bool	shown = false;		// Show window?
 	int		flags = 0;		// Flags
-	int		display = 0;	// Display number
-	int		mode[2] = {};	// Resolution or window size
-	int		depth = 0;		// Bit depth
+	int		mode[2] = {};	// Window size
 	int		minSize[2] = {};	// Minimum size for resizable windows
 	sys_vidSave_s save; // Saved state
 };

--- a/ui_main.cpp
+++ b/ui_main.cpp
@@ -237,7 +237,7 @@ void ui_main_c::Init(int argc, char** argv)
 	}
 }
 
-void ui_main_c::RenderInit()
+void ui_main_c::RenderInit(r_featureFlag_e features)
 {
 	if (renderer) {
 		return;
@@ -252,7 +252,7 @@ void ui_main_c::RenderInit()
 
 	// Initialise renderer
 	renderer = r_IRenderer::GetHandle(sys);
-	renderer->Init();
+	renderer->Init(features);
 
 	// Create UI console handler
 	conUI = ui_IConsole::GetHandle(this);

--- a/ui_main.cpp
+++ b/ui_main.cpp
@@ -95,6 +95,17 @@ void ui_main_c::LAssert(lua_State* L, int cond, const char* fmt, ...)
 	}
 }
 
+void ui_main_c::LExpect(lua_State* L, int cond, const char* fmt, ...)
+{
+	if (!cond) {
+		va_list va;
+		va_start(va, fmt);
+		lua_pushvfstring(L, fmt, va);
+		va_end(va);
+		throw ui_expectationFailed_s{};
+	}
+}
+
 int ui_main_c::IsUserData(lua_State* L, int index, const char* metaName)
 {
 	if (lua_type(L, index) != LUA_TUSERDATA || lua_getmetatable(L, index) == 0) {

--- a/ui_main.h
+++ b/ui_main.h
@@ -8,6 +8,8 @@
 // Classes
 // =======
 
+struct ui_expectationFailed_s {};
+
 // UI Manager
 class ui_main_c: public ui_IMain {
 public:
@@ -53,7 +55,8 @@ public:
 	void	ScriptInit();
 	void	ScriptShutdown();
 
-	void	LAssert(lua_State* L, int cond, const char* fmt, ...);
+	void	LAssert(lua_State* L, int cond, const char* fmt, ...); // Non-local return to Lua code on failure
+	void	LExpect(lua_State* L, int cond, const char* fmt, ...); // Throws ui_expectationFailed_s on failure, message on Lua stack
 	int		IsUserData(lua_State* L, int index, const char* metaName);
 	int		PushCallback(const char* name);
 	void	PCall(int narg, int nret);

--- a/ui_main.h
+++ b/ui_main.h
@@ -49,7 +49,7 @@ public:
 
 	static int InitAPI(lua_State* L);
 
-	void	RenderInit();
+	void	RenderInit(r_featureFlag_e features);
 	void	ScriptInit();
 	void	ScriptShutdown();
 


### PR DESCRIPTION
This PR supersedes my PRs #40, #41 and #42 for fixing the window positioning logic, adding the DPI awareness feature flag and addressing some problems around zlib usage.

It also reintroduces screenshot functionality, changes how the render queue is represented to a more efficient storage layout and adds boilerplate macros to wrap the functions exposed to Lua in a manner that allows C++ RAII usage inside the handlers as long as `LAssert` is replaced by `LExpect` which unwinds the C++ stack correctly.

The API changes between Lua and C++ are additive, no changes are needed on the Lua side apart from documenting the new flags and augment the headless wrapper when they start being used. This PR notably doesn't include the "Mesh" and "At" family of draw commands as they are not set in stone yet.

My apologies up-front for the intermingled PR as the commits are interdependent, the individual commits however have fairly verbose commit messages.