### PR TITLE
fix: harden UserPath against unusable folders

### DIFF
--- a/engine/system/sys_main.h
+++ b/engine/system/sys_main.h
@@ -64,8 +64,9 @@ public:
 	bool		debug = false;
 	bool		debuggerRunning = false;
 	int			processorCount = 0;
-	std::string	basePath;
-	std::string	userPath;
+	std::string basePath;
+	std::optional<std::string> userPath;
+	std::optional<std::string> invalidUserPath;
 
 	virtual int		GetTime() = 0;
 	virtual void	Sleep(int msec) = 0;

--- a/engine/system/win/sys_main.cpp
+++ b/engine/system/win/sys_main.cpp
@@ -712,14 +712,44 @@ std::string FindBasePath()
 #endif
 }
 
-std::string FindUserPath()
+std::optional<std::string> FindUserPath(std::optional<std::string>& invalidPath)
 {
 #ifdef _WIN32
-    PWSTR os_path{};
-    SHGetKnownFolderPath(FOLDERID_Documents, KF_FLAG_DEFAULT, nullptr, &os_path);
-    std::filesystem::path path(os_path);
-    CoTaskMemFree(os_path);
-    return path.string();
+    PWSTR osPath{};
+    HRESULT hr = SHGetKnownFolderPath(FOLDERID_Documents, KF_FLAG_DEFAULT, nullptr, &osPath);
+	if (FAILED(hr)) {
+		// The path may be inaccessible due to malfunctioning cloud providers.
+		CoTaskMemFree(osPath);
+		invalidPath.reset();
+		return {};
+	}
+	std::wstring pathStr = osPath;
+	CoTaskMemFree(osPath);
+	std::filesystem::path path(pathStr);
+	try {
+    	return path.string();
+	}
+	catch (std::system_error) {
+		// The path could not be converted into the narrow representation, convert the path
+		// string lossily for use in an ASCII error message on the Lua side.
+		invalidPath.reset();
+		std::wstring pathStr = path.wstring();
+		char defGlyph = '?';
+		BOOL defGlyphUsed{};
+		DWORD convFlags = WC_COMPOSITECHECK | WC_NO_BEST_FIT_CHARS | WC_DEFAULTCHAR;
+		int cb = WideCharToMultiByte(CP_ACP, 0, pathStr.c_str(), -1, nullptr, 0, &defGlyph, &defGlyphUsed);
+		if (cb) {
+			std::vector<char> buf(cb);
+			WideCharToMultiByte(CP_ACP, 0, pathStr.c_str(), -1, buf.data(), cb, &defGlyph, &defGlyphUsed);
+			for (auto& ch : buf) {
+				if ((unsigned char)ch >= 0x80) {
+					ch = '?'; // Substitute characters that we can represent but can't draw.
+				}
+			}
+			invalidPath = buf.data();
+		}
+		return {};
+	}
 #else
     if (char const* data_home_path = getenv("XDG_DATA_HOME")) {
         return data_home_path;
@@ -755,7 +785,7 @@ sys_main_c::sys_main_c()
 
 	// Set the local system information
 	basePath = FindBasePath();
-	userPath = FindUserPath();
+	userPath = FindUserPath(invalidUserPath);
 }
 
 bool sys_main_c::Run(int argc, char** argv)

--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -67,7 +67,7 @@
 ** msec = GetTime()
 ** path = GetScriptPath()
 ** path = GetRuntimePath()
-** path = GetUserPath()
+** path, missingPath = GetUserPath() -- may fail, then returns nil and and approximation of the bad path
 ** SetWorkDir("<path>")
 ** path = GetWorkDir()
 ** ssID = LaunchSubScript("<scriptText>", "<funcList>", "<subList>"[, ...])
@@ -1065,7 +1065,17 @@ static int l_GetRuntimePath(lua_State* L)
 static int l_GetUserPath(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
-	lua_pushstring(L, ui->sys->userPath.c_str());
+	auto& userPath = ui->sys->userPath;
+	if (userPath) {
+		lua_pushstring(L, userPath->c_str());
+		return 1;
+	}
+	
+	lua_pushnil(L);
+	if (auto& invalidUserPath = ui->sys->invalidUserPath) {
+		lua_pushstring(L, invalidUserPath->c_str());
+		return 2;
+	}
 	return 1;
 }
 


### PR DESCRIPTION
The user path location may both be inaccessible thanks to malfunctioning cloud providers and due to not being representable in the user codepage that is needed for interacting with the file system in a narrow way in Lua.

If an error occurs, the Lua function returns nil and an approximation in the user codepage of the path, suitable for use in an error message.