### PR TITLE
fix: clamp saved window size to minimum size

### DIFF
--- a/engine/core/core_video.cpp
+++ b/engine/core/core_video.cpp
@@ -92,6 +92,9 @@ void core_video_c::Apply(bool shown)
 			set.flags|= VID_MAXIMIZE;
 		} else if (vid_resizable->intVal == 3) {
 			if (sscanf(vid_last->strVal.c_str(), "%d,%d,%d,%d,%d", set.save.size + 0, set.save.size + 1, set.save.pos + 0, set.save.pos + 1, (int*)&set.save.maximised) == 5) {
+				// Clamp saved window size as it may be persisted as zero before.
+				set.save.size[0] = (std::max)(CFG_VID_MINWIDTH, set.save.size[0]);
+				set.save.size[1] = (std::max)(CFG_VID_MINHEIGHT, set.save.size[1]);
 				set.flags|= VID_USESAVED;
 			} else {
 				set.flags|= VID_MAXIMIZE;

--- a/engine/system/win/sys_video.cpp
+++ b/engine/system/win/sys_video.cpp
@@ -604,15 +604,21 @@ void sys_video_c::FramebufferSizeChanged(int width, int height) {
 
 void sys_video_c::SizeChanged(int width, int height, bool max)
 {
-	vid.size[0] = width;
-	vid.size[1] = height;
-	vid.maximised = max;
+	// Avoid persisting an invalid window size from being minimized.
+	if (!glfwGetWindowAttrib(wnd, GLFW_ICONIFIED)) {
+		vid.size[0] = width;
+		vid.size[1] = height;
+		vid.maximised = max;
+	}
 }
 
 void sys_video_c::PosChanged(int x, int y)
 {
-	vid.pos[0] = x;
-	vid.pos[1] = y;
+	// Avoid persisting an invalid window location from being minimized.
+	if (!glfwGetWindowAttrib(wnd, GLFW_ICONIFIED)) {
+		vid.pos[0] = x;
+		vid.pos[1] = y;
+	}
 }
 
 void sys_video_c::GetMinSize(int& width, int& height)


### PR DESCRIPTION
The stored `vid_last` window size in Launch.cfg (or SimpleGraphic.cfg) can have a zero window width/height recorded; this typically due to closing the program while minimized.

As we have a minimum window size enforced in general, adapt the config loading to clamp the size to the minimum size and safeguard against the erroneous size and position being stored in the first place.