### PR TITLE
fix: disable glfw dinput8 joysticks

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
       "kind": "filesystem",
       "path": "vcpkg-ports",
       "baseline": "2024-03-26",
-      "packages": ["luajit"]
+      "packages": ["glfw3", "luajit"]
     }
   ]
 }

--- a/vcpkg-ports/ports/glfw3/3.4_1/glfw-3.4_disable_dinput8.patch
+++ b/vcpkg-ports/ports/glfw3/3.4_1/glfw-3.4_disable_dinput8.patch
@@ -1,0 +1,30 @@
+From a6dd071b7cd9c3f592dbf5cf1f301df529773833 Mon Sep 17 00:00:00 2001
+From: Lars Viklund <zao@zao.se>
+Date: Sat, 30 Mar 2024 21:05:35 +0100
+Subject: [PATCH] fix: disable dinput8 to fix startup delay
+
+Some HID devices block DirectInput8 device enumeration for many seconds
+which adversely affects software that uses GLFW without needing
+joysticks at all.
+
+This change skips loading of the `dinput8` library and thus disables all
+functionality that checks for its availability.
+---
+ src/win32_init.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/win32_init.c b/src/win32_init.c
+index 824e383c..a81da94e 100644
+--- a/src/win32_init.c
++++ b/src/win32_init.c
+@@ -104,7 +104,6 @@ static GLFWbool loadLibraries(void)
+     _glfw.win32.user32.GetSystemMetricsForDpi_ = (PFN_GetSystemMetricsForDpi)
+         _glfwPlatformGetModuleSymbol(_glfw.win32.user32.instance, "GetSystemMetricsForDpi");
+ 
+-    _glfw.win32.dinput8.instance = _glfwPlatformLoadModule("dinput8.dll");
+     if (_glfw.win32.dinput8.instance)
+     {
+         _glfw.win32.dinput8.Create = (PFN_DirectInput8Create)
+-- 
+2.42.0.windows.2
+

--- a/vcpkg-ports/ports/glfw3/3.4_1/portfile.cmake
+++ b/vcpkg-ports/ports/glfw3/3.4_1/portfile.cmake
@@ -1,0 +1,61 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO glfw/glfw
+    REF ${VERSION}
+    SHA512 39ad7a4521267fbebc35d2ff0c389a56236ead5fa4bdff33db113bd302f70f5f2869ff4e6db1979512e1542813292dff5a482e94dfce231750f0746c301ae9ed
+    HEAD_REF master
+    PATCHES
+        glfw-3.4_disable_dinput8.patch
+)
+
+if(VCPKG_TARGET_IS_LINUX)
+    message(
+"GLFW3 currently requires the following libraries from the system package manager:
+    xinerama
+    xcursor
+    xorg
+    libglu1-mesa
+    pkg-config
+
+These can be installed on Ubuntu systems via sudo apt install libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev pkg-config
+
+Alternatively, when targeting the Wayland display server, use the packages listed in the GLFW documentation here:
+
+https://www.glfw.org/docs/3.3/compile.html#compile_deps_wayland")
+else(VCPKG_TARGET_IS_OSX)
+    message(
+"GLFW3 currently requires the following libraries from the system package manager:
+    xinerama
+    xcursor
+    xorg
+    libglu1-mesa
+    pkg-config
+
+These can be installed via brew install libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev pkg-config")
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    wayland         GLFW_BUILD_WAYLAND
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DGLFW_BUILD_EXAMPLES=OFF
+        -DGLFW_BUILD_TESTS=OFF
+        -DGLFW_BUILD_DOCS=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/glfw3)
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/vcpkg-ports/ports/glfw3/3.4_1/vcpkg.json
+++ b/vcpkg-ports/ports/glfw3/3.4_1/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "glfw3",
+  "version": "3.4",
+  "port-version": 1,
+  "description": "GLFW is a free, Open Source, multi-platform library for OpenGL, OpenGL ES and Vulkan application development. It provides a simple, platform-independent API for creating windows, contexts and surfaces, reading input, handling events, etc.",
+  "homepage": "https://github.com/glfw/glfw",
+  "license": "Zlib",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "wayland": {
+      "description": "Use Wayland display server",
+      "supports": "linux",
+      "dependencies": [
+        "wayland"
+      ]
+    }
+  }
+}

--- a/vcpkg-ports/versions/baseline.json
+++ b/vcpkg-ports/versions/baseline.json
@@ -3,6 +3,7 @@
         "luajit": { "baseline": "2022-08-11", "port-version": 1 }
     },
     "2024-03-26": {
+        "glfw3": { "baseline": "3.4", "port-version": 1 },
         "luajit": { "baseline": "2023-04-16", "port-version": 0 }
     }
 }

--- a/vcpkg-ports/versions/g-/glfw3.json
+++ b/vcpkg-ports/versions/g-/glfw3.json
@@ -1,0 +1,9 @@
+{
+    "versions": [
+      {
+        "version": "3.4",
+        "port-version": 1,
+        "path": "$/ports/glfw3/3.4_1"
+      }
+    ]
+}


### PR DESCRIPTION
Some HID devices block DirectInput8 device enumeration for many seconds which adversely affects software that uses GLFW without needing joysticks at all.

This change vendors the a port for GLFW with a patch to not load the `dinput8` library and thus disables all functionality that checks for its availability.