### PR TITLE
ci: update all actions to current, update vcpkg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,24 +10,25 @@ jobs:
             triplet: x64-windows
     runs-on: ${{ matrix.os }}
     env:
-      VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}-release
+      VCPKG_TARGET_TRIPLET: ${{ matrix.triplet }}-release
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed/
       DEPS_DIR: ${{ github.workspace }}/vcpkg_installed/${{ matrix.triplet }}
       INST_DIR: ${{ github.workspace }}/install-prefix
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
       - name: run-vcpkg
-        uses: lukka/run-vcpkg@v10
+        uses: lukka/run-vcpkg@v11
         with:
           vcpkgJsonGlob: "./vcpkg.json"
           runVcpkgInstall: true
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v2
 
       - name: Obtain and run CMake
         uses: threeal/cmake-action@v1.3.0
@@ -35,25 +36,25 @@ jobs:
           source-dir: "."
           build-dir: "build"
           generator: "Visual Studio 17 2022"
-          options: CMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake CMAKE_INSTALL_PREFIX="${{ env.INST_DIR }}"
+          options: CMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake CMAKE_INSTALL_PREFIX="${{ env.INST_DIR }}" VCPKG_TARGET_TRIPLET="${{ env.VCPKG_TARGET_TRIPLET }}"
 
       - name: Build DLL
         run: "cmake --build build --config Release -t INSTALL"
         
       - name: Archive DLL
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SimpleGraphic-${{ matrix.triplet }}.dll
           path: "${{ env.INST_DIR }}/SimpleGraphic.dll"
 
       - name: Archive DLL symbols
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SimpleGraphic-${{ matrix.triplet }}.pdb
           path: "${{ github.workspace }}/build/Release/SimpleGraphic.pdb"
 
       - name: Archive dependency DLLs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SimpleGraphic-${{ matrix.triplet }}-deps.dll
           path: |
@@ -61,7 +62,7 @@ jobs:
             !${{ env.INST_DIR }}/SimpleGraphic.dll
 
       - name: Archive dependency DLL symbols
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SimpleGraphic-${{ matrix.triplet }}-deps.pdb
           path: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,17 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
 endif ()
 
 if (WIN32)
+    target_compile_options(SimpleGraphic
+        PRIVATE
+        "/EHa"
+    )
+    target_compile_definitions(SimpleGraphic
+        PRIVATE
+        "_CRT_SECURE_NO_DEPRECATE=1"
+        "_CRT_SECURE_NO_WARNINGS=1"
+        "_SCL_SECURE_NO_DEPRECATE=1"
+        "_SCL_SECURE_NO_WARNINGS=1"
+    )
     target_link_libraries(SimpleGraphic
         PRIVATE
         "winmm.lib"
@@ -198,39 +209,30 @@ install(TARGETS SimpleGraphic RUNTIME DESTINATION ".")
 if (WIN32)
     set(DEPS_DIR "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}")
 
-    find_file(LuaJIT_DLL_DEBUG
-        NAMES "lua51.dll"
-        PATHS "${DEPS_DIR}"
-        PATH_SUFFIXES "debug/bin"
-        REQUIRED
-        NO_DEFAULT_PATH
-    )
-    find_file(LuaJIT_DLL_RELEASE
-        NAMES "lua51.dll"
-        PATHS "${DEPS_DIR}"
-        PATH_SUFFIXES "bin"
-        REQUIRED
-        NO_DEFAULT_PATH
-    )
-    find_file(ZLIB_DLL_DEBUG
-        NAMES "zlibd1.dll"
-        PATHS "${DEPS_DIR}"
-        PATH_SUFFIXES "debug/bin"
-        REQUIRED
-        NO_DEFAULT_PATH
-    )
-    find_file(ZLIB_DLL_RELEASE
-        NAMES "zlib1.dll"
-        PATHS "${DEPS_DIR}"
-        PATH_SUFFIXES "bin"
-        REQUIRED
-        NO_DEFAULT_PATH
+    if (NOT VCPKG_TARGET_TRIPLET MATCHES "-release")
+        find_file(LuaJIT_DLL_DEBUG NAMES "lua51.dll"
+            PATHS "${DEPS_DIR}" PATH_SUFFIXES "debug/bin" REQUIRED NO_DEFAULT_PATH)
+        find_file(ZLIB_DLL_DEBUG NAMES "zlibd1.dll"
+            PATHS "${DEPS_DIR}" PATH_SUFFIXES "debug/bin" REQUIRED NO_DEFAULT_PATH)
+             
+        install(FILES
+            ${LuaJIT_DLL_DEBUG}
+            ${ZLIB_DLL_DEBUG}
+            DESTINATION "."
+            CONFIGURATIONS Debug
+        )
+    endif ()
+
+    find_file(LuaJIT_DLL_RELEASE NAMES "lua51.dll"
+        PATHS "${DEPS_DIR}" PATH_SUFFIXES "bin" REQUIRED NO_DEFAULT_PATH)
+    find_file(ZLIB_DLL_RELEASE NAMES "zlib1.dll"
+        PATHS "${DEPS_DIR}" PATH_SUFFIXES "bin" REQUIRED NO_DEFAULT_PATH
     )
 
-    install(FILES ${LuaJIT_DLL_DEBUG} ${ZLIB_DLL_DEBUG} DESTINATION "."
-        CONFIGURATIONS Debug
-    )
-    install(FILES ${LuaJIT_DLL_RELEASE} ${ZLIB_DLL_RELEASE} DESTINATION "."
+    install(FILES
+        ${LuaJIT_DLL_RELEASE}
+        ${ZLIB_DLL_RELEASE}
+        DESTINATION "."
         CONFIGURATIONS Release MinSizeRel RelWithDebInfo
     )
 endif ()

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "builtin",
-    "baseline": "836a2d684dac6b543563e53ab30a1a5b8afaf97b"
+    "baseline": "3d72d8c930e1b6a1b2432b262c61af7d3287dcd0"
   },
   "registries": [
     {


### PR DESCRIPTION
Most versions are trivial mostly revising the underlying node version required. Artifact uploading is changed significantly but not in any way that affect us.

chore: update vcpkg to master (2024-07-11)

Update vcpkg and the matching registry override to master as previous instabilities seem to have been addressed by now. 2024.06.15 isn't good enough as Abseil fails to build there.

fix: omit debug DLLs for release-only triplet

When building in CI with a `x64-windows-release` triplet to cut down on binary cache size and build times, the logic in the CMake script needs to not search for debug DLLs as no such files exist.

(cherry picked from commit c1ed5b6afb5de41addac75a5e382e8a7221ed864)