### PR TITLE
Expose std::filesystem::remove_all functionality to lua side as an argument for RemoveDir

### DIFF
--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -1102,11 +1102,13 @@ static int l_RemoveDir(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
 	int n = lua_gettop(L);
-	ui->LAssert(L, n >= 1, "Usage: l_RemoveDir(path)");
+	ui->LAssert(L, n >= 2, "Usage: l_RemoveDir(path, recurse)");
 	ui->LAssert(L, lua_isstring(L, 1), "l_RemoveDir() argument 1: expected string, got %s", luaL_typename(L, 1));
+	ui->LAssert(L, n > 1 && lua_isboolean(L ,2), "l_RemoveDir() argument 2: expected boolean, got %s", luaL_typename(L, 2));
 	std::filesystem::path path(lua_tostring(L, 1));
+	bool const recursive = n > 1 && lua_toboolean(L, 2);
 	std::error_code ec;
-	if (!is_directory(path, ec) || ec || !remove(path, ec) || ec) {
+	if (!is_directory(path, ec) || ec || !(recursive && !remove_all(path, ec)) || ec || !remove(path, ec) || ec) {
 		lua_pushnil(L);
 		lua_pushstring(L, strerror(ec.value()));
 		return 2;

--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -1102,13 +1102,19 @@ static int l_RemoveDir(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
 	int n = lua_gettop(L);
-	ui->LAssert(L, n >= 2, "Usage: l_RemoveDir(path, recurse)");
+	ui->LAssert(L, n >= 1, "Usage: l_RemoveDir(path, recurse)");
 	ui->LAssert(L, lua_isstring(L, 1), "l_RemoveDir() argument 1: expected string, got %s", luaL_typename(L, 1));
-	ui->LAssert(L, n > 1 && lua_isboolean(L ,2), "l_RemoveDir() argument 2: expected boolean, got %s", luaL_typename(L, 2));
+	
 	std::filesystem::path path(lua_tostring(L, 1));
-	bool const recursive = n > 1 && lua_toboolean(L, 2);
+	bool recursive = false;
+
+	if (n > 1) {
+		ui->LAssert(L, lua_isboolean(L, 2), "l_RemoveDir() argument 2: expected boolean, got %s", luaL_typename(L, 2));
+		recursive = lua_toboolean(L, 2);
+	}
+
 	std::error_code ec;
-	if (!is_directory(path, ec) || ec || !(recursive && !remove_all(path, ec)) || ec || !remove(path, ec) || ec) {
+	if (!is_directory(path, ec) || ec || (recursive && !remove_all(path, ec)) || ec || !remove(path, ec) || ec) {
 		lua_pushnil(L);
 		lua_pushstring(L, strerror(ec.value()));
 		return 2;

--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -1104,7 +1104,7 @@ static int l_RemoveDir(lua_State* L)
 	int n = lua_gettop(L);
 	ui->LAssert(L, n >= 1, "Usage: l_RemoveDir(path, recurse)");
 	ui->LAssert(L, lua_isstring(L, 1), "l_RemoveDir() argument 1: expected string, got %s", luaL_typename(L, 1));
-	
+
 	std::filesystem::path path(lua_tostring(L, 1));
 	bool recursive = false;
 
@@ -1114,7 +1114,10 @@ static int l_RemoveDir(lua_State* L)
 	}
 
 	std::error_code ec;
-	if (!is_directory(path, ec) || ec || (recursive && !remove_all(path, ec)) || ec || !remove(path, ec) || ec) {
+	if (!is_directory(path, ec) || ec
+		|| (recursive && !remove_all(path, ec)) || ec
+		|| (!recursive && !remove(path, ec)) || ec)
+	{
 		lua_pushnil(L);
 		lua_pushstring(L, strerror(ec.value()));
 		return 2;


### PR DESCRIPTION
Current implementation of RemoveDir does not allow for removal of directories with content. This commit adds a recursive boolean parameter to RemoveDir allowing for recursive removal of directories and their contents.

See https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/8197 for more discussion and potential use case.