### PR TITLE
Expose sceenshot funcitonality to lua. Remove screenshot hotkey.

### DIFF
--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -1444,6 +1444,13 @@ static int l_Exit(lua_State* L)
 	return 0;
 }
 
+static int l_TakeScreenshot(lua_State* L)
+{
+	ui_main_c* ui = GetUIPtr(L);
+	ui->sys->con->Execute("screenshot");
+	return 0;
+}
+
 // ==============================
 // Library and API Initialisation
 // ==============================
@@ -1573,6 +1580,7 @@ int ui_main_c::InitAPI(lua_State* L)
 	ADDFUNC(SpawnProcess);
 	ADDFUNC(OpenURL);
 	ADDFUNC(SetProfiling);
+	ADDFUNC(TakeScreenshot);
 	ADDFUNC(Restart);
 	ADDFUNC(Exit);
 	lua_getglobal(L, "os");

--- a/ui_main.cpp
+++ b/ui_main.cpp
@@ -514,9 +514,6 @@ void ui_main_c::KeyEvent(int key, int type)
 		break;
 	case KE_KEYUP:
 		switch (key) {
-		case KEY_PRINTSCRN:
-			sys->con->Execute("screenshot");
-			break;
 		case KEY_F10:
 			renderer->ToggleDebugImGui();
 			break;


### PR DESCRIPTION
Following discussion regarding https://github.com/PathOfBuildingCommunity/PathOfBuilding-SimpleGraphic/pull/64 on discord it had been suggested that it may be beneficial to handle the screenshot hotkey from lua.

This pr adds a new function available from lua, `TakeScreenshot`, which allows for taking screenshots using the existing SimpleGraphic screenshot code. The hotkey to call the functionality directly inside of SG was removed as it was considered redundant.