### PR TITLE
Expose SetForeground function to Lua API

### DIFF
--- a/engine/system/sys_video.h
+++ b/engine/system/sys_video.h
@@ -47,7 +47,6 @@ public:
 
 	virtual	int		Apply(sys_vidSet_s* set) = 0;	// Apply settings
 
-	virtual	void	SetActive(bool active) = 0;		// Respond to window activated status change
 	virtual void	SetForeground() = 0; // Activate the window if shown
 	virtual bool	IsActive() = 0; // Get activated status
 	virtual void	FramebufferSizeChanged(int width, int height) = 0; // Respond to framebuffer size change

--- a/engine/system/win/sys_video.cpp
+++ b/engine/system/win/sys_video.cpp
@@ -29,7 +29,6 @@ public:
 	// Interface
 	int		Apply(sys_vidSet_s* set);
 
-	void	SetActive(bool active);
 	void	SetForeground();
 	bool	IsActive();
 	void	FramebufferSizeChanged(int width, int height);
@@ -655,13 +654,6 @@ int sys_video_c::Apply(sys_vidSet_s* set)
 
 	initialised = true;
 	return 0;
-}
-
-void sys_video_c::SetActive(bool active)
-{
-	if (initialised) {
-		glfwFocusWindow(wnd);
-	}
 }
 
 void sys_video_c::SetForeground()

--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -104,6 +104,7 @@
 ** SetProfiling(isEnabled)
 ** Restart()
 ** Exit(["<message>"])
+** SetForeground()
 */
 
 // Grab UI main pointer from the registry
@@ -1952,6 +1953,13 @@ static int l_TakeScreenshot(lua_State* L)
 	return 0;
 }
 
+static int l_SetForeground(lua_State* L)
+{
+	ui_main_c* ui = GetUIPtr(L);
+	ui->sys->video->SetForeground();
+	return 0;
+}
+
 // ==============================
 // Library and API Initialisation
 // ==============================
@@ -2128,6 +2136,7 @@ int ui_main_c::InitAPI(lua_State* L)
 	ADDFUNC(TakeScreenshot);
 	ADDFUNC(Restart);
 	ADDFUNC(Exit);
+	ADDFUNC(SetForeground);
 	lua_getglobal(L, "os");
 	lua_pushcfunction(L, l_Exit);
 	lua_setfield(L, -2, "exit");


### PR DESCRIPTION
This PR allows Lua to set PoB as the active window for things like the final step of the OAuth flow.  As far as I can tell, Windows just flashes the taskbar icon, which should be sufficient for this purpose.

This also removes a redundant function that had the same functionality.