### PR TITLE
feat: add BC7 CPU decode for legacy GPUs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "libs/luautf8"]
 	path = libs/luautf8
 	url = https://github.com/starwing/luautf8.git
+[submodule "dep/compressonator"]
+	path = dep/compressonator
+	url = https://github.com/GPUOpen-Tools/compressonator

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,21 @@ find_package(Threads REQUIRED)
 find_package(zstd REQUIRED)
 find_package(ZLIB REQUIRED)
 
+add_library(cmp_core STATIC
+    dep/compressonator/cmp_core/source/cmp_core.cpp
+    dep/compressonator/cmp_core/source/cmp_core.h
+    dep/compressonator/cmp_core/shaders/bc3_encode_kernel.cpp
+    dep/compressonator/cmp_core/shaders/bc7_encode_kernel.cpp
+)
+
+target_include_directories(cmp_core PRIVATE
+    dep/compressonator/applications/_libs/cmp_math
+)
+
+target_include_directories(cmp_core PUBLIC
+    dep/compressonator/cmp_core/shaders
+    dep/compressonator/cmp_core/source
+)
 
 add_library(imgui STATIC
     dep/imgui/imconfig.h
@@ -203,6 +218,7 @@ target_link_libraries(SimpleGraphic
     PRIVATE
     unofficial::angle::libEGL
     unofficial::angle::libGLESv2
+    cmp_core
     fmt::fmt
     glfw
     gli

--- a/engine/render/r_main.cpp
+++ b/engine/render/r_main.cpp
@@ -920,6 +920,15 @@ void r_renderer_c::Init(r_featureFlag_e features)
 		glCompressedTexImage2D = NULL;
 	}
 
+	if (strstr(st_ext, "GL_EXT_texture_compression_bptc")) {
+		sys->con->Printf("using GL_EXT_texture_compression_bptc\n");
+		texBC7 = true;
+	}
+	else {
+		sys->con->Printf("GL_EXT_texture_compression_bptc not supported\n");
+		texBC7 = false;
+	}
+
 	if (strstr(st_ext, "GL_EXT_debug_marker")) {
 		sys->con->Printf("using GL_EXT_debug_marker\n");
 		glInsertEventMarkerEXT = (PFNGLINSERTEVENTMARKEREXTPROC)openGL->GetProc("glInsertEventMarkerEXT");

--- a/engine/render/r_main.h
+++ b/engine/render/r_main.h
@@ -120,6 +120,7 @@ public:
 
 	bool	texNonPOT = false;			// Non power-of-2 textures supported?
 	dword	texMaxDim = 0;				// Maximum texture dimension
+	bool	texBC7 = true;				// BC7 textures supported?
 
 	PFNGLCOMPRESSEDTEXIMAGE2DPROC	glCompressedTexImage2D = nullptr;
 	PFNGLINSERTEVENTMARKEREXTPROC	glInsertEventMarkerEXT = nullptr;


### PR DESCRIPTION
While ANGLE itself runs on legacy feature levels (10.0, 10.1); support for 11.0+ texture formats like BC7 is absent.

To support this lower end of GPUs we introduce fallback logic to transcode BC7 into RGBA with a hardcoded option to also reduce texture resolution by one level to counteract the 4x increase in VRAM usage this entails.

This adds a dependency on `cmp_core` from GPUOpen's Compressonator, built as a static library so there's no runtime deployment concerns.