### PR TITLE
fix: vendor gli port for cmake 4.0 compatibility

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
       "kind": "filesystem",
       "path": "vcpkg-ports",
       "baseline": "2025-01-19",
-      "packages": ["glfw3", "luajit"]
+      "packages": ["glfw3", "gli", "luajit"]
     }
   ]
 }

--- a/vcpkg-ports/ports/gli/2021-07-06_3/bump-cmake-version.patch
+++ b/vcpkg-ports/ports/gli/2021-07-06_3/bump-cmake-version.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6f70f493..7d7828b4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.15)
+ cmake_policy(SET CMP0054 NEW)
+ 
+ project(gli)

--- a/vcpkg-ports/ports/gli/2021-07-06_3/disable-test.patch
+++ b/vcpkg-ports/ports/gli/2021-07-06_3/disable-test.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6eb1a68..610c0bc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -71,7 +71,7 @@ endmacro(addExternalPackageGTC)
+ # Add subdirectory
+ 
+ add_subdirectory(gli)
+-add_subdirectory(test)
++#add_subdirectory(test)
+ #add_subdirectory(doc)
+ 
+ ################################

--- a/vcpkg-ports/ports/gli/2021-07-06_3/portfile.cmake
+++ b/vcpkg-ports/ports/gli/2021-07-06_3/portfile.cmake
@@ -1,0 +1,28 @@
+#header-only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO g-truc/gli
+    REF 779b99ac6656e4d30c3b24e96e0136a59649a869
+    SHA512 6e7ab46b7943cb185c8c1f6e45b765f5463e03628973043a0e8b866458ccceb5249f69a2a77b5e69c73f3ace85af96c7b9b2137685ceb6d0fcb67e491a49be69
+    HEAD_REF master
+    PATCHES
+        bump-cmake-version.patch
+        disable-test.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/gli)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/include/gli/CMakeLists.txt")
+
+# Put the license file where vcpkg expects it
+# manual.md contains the "licenses" section for the project
+file(INSTALL "${SOURCE_PATH}/manual.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/vcpkg-ports/ports/gli/2021-07-06_3/vcpkg.json
+++ b/vcpkg-ports/ports/gli/2021-07-06_3/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "gli",
+  "version-date": "2021-07-06",
+  "port-version": 3,
+  "description": "OpenGL Image (GLI)",
+  "homepage": "https://gli.g-truc.net",
+  "dependencies": [
+    "glm",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg-ports/versions/baseline.json
+++ b/vcpkg-ports/versions/baseline.json
@@ -4,6 +4,7 @@
     },
     "2025-01-19": {
         "glfw3": { "baseline": "3.4", "port-version": 1 },
+        "gli": { "baseline": "2021-07-06", "port-version": 3 },
         "luajit": { "baseline": "2023-04-16", "port-version": 1 }
     }
 }

--- a/vcpkg-ports/versions/g-/gli.json
+++ b/vcpkg-ports/versions/g-/gli.json
@@ -1,0 +1,9 @@
+{
+    "versions": [
+      {
+        "version-date": "2021-07-06",
+        "port-version": 3,
+        "path": "$/ports/gli/2021-07-06_3"
+      }
+    ]
+}


### PR DESCRIPTION
CMake 4.0 removed previously deprecated backwards compatibility for CMake versions less than 3.5.

As the GitHub action runner for `windows-latest` now has CMake 4.0, our CI runs have started failing. To address this we vendor the `gli` port from upstream `vcpkg` with a patch to bump its minimum CMake requirement declared in the `gli` CMake scripts.