### PR TITLE
Expose ACP versions of the base/script/user paths

### DIFF
--- a/engine/common/common.cpp
+++ b/engine/common/common.cpp
@@ -484,7 +484,7 @@ IndexedUTF32String IndexUTF8ToUTF32(std::string_view input)
 			byteIdx += 4;
 		}
 		else {
-			codepoints.push_back(0xFFFDu);
+			codepoint = 0xFFFDu;
 			byteIdx += 1;
 		}
 		codepoints.push_back(codepoint);

--- a/engine/system/sys_main.h
+++ b/engine/system/sys_main.h
@@ -69,6 +69,7 @@ public:
 	int			processorCount = 0;
 	std::filesystem::path basePath;
 	std::optional<std::filesystem::path> userPath;
+	std::optional<std::string> userPathReason;
 
 	virtual int		GetTime() = 0;
 	virtual void	Sleep(int msec) = 0;

--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -85,9 +85,9 @@
 ** compressed = Deflate(uncompressed)
 ** uncompressed = Inflate(compressed)
 ** msec = GetTime()
-** path = GetScriptPath()
-** path = GetRuntimePath()
-** path = GetUserPath() -- may return nil if the user path could not be determined
+** path[, pathACP[, err]] = GetScriptPath()
+** path[, pathACP[, err]] = GetRuntimePath()
+** path[, pathACP[, err]] = GetUserPath() -- may return nil if the user path could not be determined
 ** SetWorkDir("<path>")
 ** path = GetWorkDir()
 ** ssID = LaunchSubScript("<scriptText>", "<funcList>", "<subList>"[, ...])
@@ -1544,25 +1544,63 @@ static int l_GetScriptPath(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
 	lua_pushstring(L, ui->scriptPath.generic_u8string().c_str());
-	return 1;
+	try
+	{
+		lua_pushstring(L, ui->scriptPath.generic_string().c_str());
+		return 2;
+	}
+	catch (std::exception& e)
+	{
+		lua_pushnil(L);
+		lua_pushstring(L, e.what());
+		return 3;
+	}
 }
 
 static int l_GetRuntimePath(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
 	lua_pushstring(L, ui->sys->basePath.generic_u8string().c_str());
-	return 1;
+	try
+	{
+		lua_pushstring(L, ui->sys->basePath.generic_string().c_str());
+		return 2;
+	}
+	catch (std::exception& e)
+	{
+		lua_pushnil(L);
+		lua_pushstring(L, e.what());
+		return 3;
+	}
 }
 
 static int l_GetUserPath(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
 	auto& userPath = ui->sys->userPath;
-	if (userPath) {
-		lua_pushstring(L, userPath->generic_u8string().c_str());
-		return 1;
+	if (!userPath) {
+		lua_pushnil(L);
+		lua_pushnil(L);
+		if (auto& reason = ui->sys->userPathReason)
+		{
+			lua_pushstring(L, reason->c_str());
+			return 3;
+		}
+		return 2;
 	}
-	return 0;
+
+	lua_pushstring(L, userPath->generic_u8string().c_str());
+	try
+	{
+		lua_pushstring(L, userPath->generic_string().c_str());
+		return 2;
+	}
+	catch (std::exception& e)
+	{
+		lua_pushnil(L);
+		lua_pushstring(L, e.what());
+		return 3;
+	}
 }
 
 static int l_MakeDir(lua_State* L)


### PR DESCRIPTION
This PR makes the three path query functions also expose an ACP encoding of the path if possible. The user path query can now also return a human-readable reason when it can't be obtained from the OS.

This is useful for scripts as they can now tell if paths can be expressed in the user's codepage.

This enables an use case in the update preparation logic where it can form absolute paths if the path is entirely within the ACP. When relative paths were in use there to work around that the path could be unspellable, the wrong directory could be operated on thanks to filesystem virtualisation.