### PR TITLE
DPI scaling supported added to the DLL

### DIFF
--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -1093,7 +1093,7 @@ static int l_DrawStringWidth(lua_State* L)
 	const float dpiScale = ui->renderer->VirtualScreenScaleFactor();
 	lua_pushinteger(L, ui->renderer->DrawStringWidth((int)lua_tointeger(L, 1) * dpiScale, 
 	luaL_checkoption(L, 2, "FIXED", fontMap), 
-	lua_tostring(L, 3)) / dpiScale);
+	lua_tostring(L, 3)));
 	return 1;
 }
 
@@ -1102,6 +1102,7 @@ static int l_DrawStringCursorIndex(lua_State* L)
 	ui_main_c* ui = GetUIPtr(L);
 	ui->LAssert(L, ui->renderer != NULL, "Renderer is not initialised");
 	int n = lua_gettop(L);
+	const float dpiScale = ui->renderer->VirtualScreenScaleFactor();
 	ui->LAssert(L, n >= 5, "Usage: DrawStringCursorIndex(height, font, text, cursorX, cursorY)");
 	ui->LAssert(L, lua_isnumber(L, 1), "DrawStringCursorIndex() argument 1: expected number, got %s", luaL_typename(L, 1));
 	ui->LAssert(L, lua_isstring(L, 2), "DrawStringCursorIndex() argument 2: expected string, got %s", luaL_typename(L, 2));
@@ -1109,7 +1110,10 @@ static int l_DrawStringCursorIndex(lua_State* L)
 	ui->LAssert(L, lua_isnumber(L, 4), "DrawStringCursorIndex() argument 4: expected number, got %s", luaL_typename(L, 4));
 	ui->LAssert(L, lua_isnumber(L, 5), "DrawStringCursorIndex() argument 5: expected number, got %s", luaL_typename(L, 5));
 	static const char* fontMap[4] = { "FIXED", "VAR", "VAR BOLD", NULL };
-	lua_pushinteger(L, ui->renderer->DrawStringCursorIndex((int)lua_tointeger(L, 1), luaL_checkoption(L, 2, "FIXED", fontMap), lua_tostring(L, 3), (int)lua_tointeger(L, 4), (int)lua_tointeger(L, 5)) + 1);
+	lua_pushinteger(L, ui->renderer->DrawStringCursorIndex((int)lua_tointeger(L, 1) * dpiScale,
+	luaL_checkoption(L, 2, "FIXED", fontMap),
+	lua_tostring(L, 3),
+	(int)lua_tointeger(L, 4) * dpiScale, (int)lua_tointeger(L, 5) * dpiScale) + 1);
 	return 1;
 }
 
@@ -1405,8 +1409,8 @@ static int l_SetCursorPos(lua_State* L)
 	ui->LAssert(L, n >= 2, "Usage: SetCursorPos(x, y)");
 	ui->LAssert(L, lua_isnumber(L, 1), "SetCursorPos() argument 1: expected number, got %s", luaL_typename(L, 1));
 	ui->LAssert(L, lua_isnumber(L, 2), "SetCursorPos() argument 2: expected number, got %s", luaL_typename(L, 2));
-	int x = ui->renderer->VirtualUnmap((int)lua_tointeger(L, 1) / dpiScale);
-	int y = ui->renderer->VirtualUnmap((int)lua_tointeger(L, 2) / dpiScale);
+	int x = ui->renderer->VirtualUnmap((int)lua_tointeger(L, 1) * dpiScale);
+	int y = ui->renderer->VirtualUnmap((int)lua_tointeger(L, 2) * dpiScale);
 	ui->sys->video->SetRelativeCursor(x, y);
 	return 0;
 }


### PR DESCRIPTION
1. Added DPI scaling to the ui_api.cpp, now the SetViewPort, DrawImage, DrawImageQuad, DrawString, DrawStringWidth, GetCursorPos and SetCursorPos function can scale with windows scale settings. Some usage of these functions in lua files from POB and POB 2 are coded in the lua scripts, so they still need to be adjusted accordingly.
Here are some beautiful 4K screenshots: 
<img width="3839" height="2061" alt="Screenshot 2025-09-18 021946" src="https://github.com/user-attachments/assets/19e41bcd-a750-4b0f-9dca-d6c8a5373765" />
<img width="3839" height="2068" alt="Screenshot 2025-09-18 021953" src="https://github.com/user-attachments/assets/a1002208-f547-4a68-abc3-d9ee900494e9" />
<img width="3839" height="2058" alt="Screenshot 2025-09-18 022005" src="https://github.com/user-attachments/assets/9dcc15dc-3a75-4fe9-8691-73dc691b0104" />
<img width="3839" height="2060" alt="Screenshot 2025-09-18 022011" src="https://github.com/user-attachments/assets/37e50e3c-e9fc-4e16-8b31-bf7657ec2261" />
