### PR TITLE
Track draw color for tooltip stuff

### DIFF
--- a/engine/render.h
+++ b/engine/render.h
@@ -96,6 +96,7 @@ public:
 	virtual void	SetBlendMode(int mode) = 0;
 	virtual void	DrawColor(const col4_t col = NULL) = 0;
 	virtual void	DrawColor(dword col) = 0;
+	virtual void	GetDrawColor(col4_t color) = 0;
 	virtual void	DrawImage(r_shaderHnd_c* hnd, glm::vec2 pos, glm::vec2 extent, glm::vec2 uv1 = { 0, 0 }, glm::vec2 uv2 = { 1, 1 }, int stackLayer = 0, std::optional<int> maskLayer = {}) = 0;
 	virtual void	DrawImageQuad(r_shaderHnd_c* hnd, glm::vec2 p0, glm::vec2 p1, glm::vec2 p2, glm::vec2 p3, glm::vec2 uv0 = { 0, 0 }, glm::vec2 uv1 = { 1, 0 }, glm::vec2 uv2 = { 1, 1 }, glm::vec2 uv3 = { 0, 1 }, int stackLayer = 0, std::optional<int> maskLayer = {}) = 0;
 	virtual void	DrawString(float x, float y, int align, int height, const col4_t col, int font, const char* str) = 0;

--- a/engine/render/r_main.cpp
+++ b/engine/render/r_main.cpp
@@ -1749,6 +1749,14 @@ void r_renderer_c::DrawColor(dword col)
 	drawColor[3] = (col >> 24) / 255.0f;
 }
 
+void r_renderer_c::GetDrawColor(col4_t color)
+{
+	color[0] = drawColor[0];
+	color[1] = drawColor[1];
+	color[2] = drawColor[2];
+	color[3] = drawColor[3];
+}
+
 void r_renderer_c::DrawImage(r_shaderHnd_c* hnd, glm::vec2 pos, glm::vec2 extent, glm::vec2 uv1, glm::vec2 uv2, int stackLayer, std::optional<int> maskLayer)
 {
 	DrawImageQuad(hnd,

--- a/engine/render/r_main.h
+++ b/engine/render/r_main.h
@@ -89,6 +89,7 @@ public:
 	void	SetBlendMode(int mode);
 	void	DrawColor(const col4_t col = NULL);
 	void	DrawColor(dword col);
+	void	GetDrawColor(col4_t color);
 	void	DrawImage(r_shaderHnd_c* hnd, glm::vec2 pos, glm::vec2 extent, glm::vec2 uv1 = { 0, 0 }, glm::vec2 uv2 = { 1, 1 }, int stackLayer = 0, std::optional<int> maskLayer = {});
 	void	DrawImageQuad(r_shaderHnd_c* hnd, glm::vec2 p0, glm::vec2 p1, glm::vec2 p2, glm::vec2 p3, glm::vec2 uv0 = { 0, 0 }, glm::vec2 uv1 = { 1, 0 }, glm::vec2 uv2 = { 1, 1 }, glm::vec2 uv3 = { 0, 1 }, int stackLayer = 0, std::optional<int> maskLayer = {});
 	void	DrawString(float x, float y, int align, int height, const col4_t col, int font, const char* str);

--- a/ui_main.h
+++ b/ui_main.h
@@ -52,6 +52,8 @@ public:
 	bool	hasActiveCoroutine = false;
 	int		ioOpenf = LUA_NOREF;
 
+	float lastColor[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+
 	static int InitAPI(lua_State* L);
 
 	void	RenderInit(r_featureFlag_e features);


### PR DESCRIPTION
When adding the desecrated background images for mods on items, and the white image on skill gems, any lines that would get wrapped would print white for the latter lines. DrawString I guess strips the color code out and applies the color to the text, but doesn't set the universal draw color. So I needed a way to track the last used draw color (in this case from the text hex), print the background image in white, and then restore the last used color so that the text continues to use either supported or unsupported text coloring. Or any coloring for that matter.

Please take a look, I used mostly Claude for this, my brain only does Lua now, and we are lucky it can even do that.