### PR TITLE
PoB Process count

### DIFF
--- a/engine/system/sys_main.h
+++ b/engine/system/sys_main.h
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <vector>
 
 // =======
 // Classes
@@ -78,6 +79,7 @@ public:
 	virtual char*	ClipboardPaste() = 0;
 	virtual bool	SetWorkDir(std::filesystem::path const& newCwd = {}) = 0;
 	virtual void	SpawnProcess(std::filesystem::path cmdName, const char* argList) = 0;
+	virtual int		GetProcessCount(const std::vector<std::wstring>& imageNames) = 0;
 	virtual std::optional<std::string> OpenURL(const char* url) = 0;
 	virtual void	Error(const char* fmt, ...) = 0;
 	virtual void	Exit(const char* msg = NULL) = 0;

--- a/engine/system/win/sys_local.h
+++ b/engine/system/win/sys_local.h
@@ -37,6 +37,7 @@ public:
 	char*	ClipboardPaste();
 	bool	SetWorkDir(std::filesystem::path const& newCwd = {});
 	void	SpawnProcess(std::filesystem::path cmdName, const char* argList);
+	int		GetProcessCount(const std::vector<std::wstring>& imageNames);
 	std::optional<std::string> OpenURL(const char* url); // return value has failure reason
 	void	Error(const char* fmt, ...);
 	void	Exit(const char* msg = NULL);


### PR DESCRIPTION
The new `GetProcessCount` helper (sys_main.cpp:438) walks the system process list via Windows’ Toolhelp API—no external commands. It creates a snapshot with `CreateToolhelp32Snapshot`, iterates `PROCESSENTRY32W`, lowercases each executable name, and increments a counter whenever the name matches one of the PoB executable variants passed in from Lua. That count flows back through the Lua binding (ui_api.cpp:2024) up to `getMatchingProcessCount` in src/Launch.lua:20, so the updater knows exactly how many sibling PoB processes are running.
