### PR TITLE
Update vcpkg and dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,6 @@ target_link_libraries(SimpleGraphic
     LuaJIT::LuaJIT
     Microsoft.GSL::GSL
     re2::re2
-    sol2
     Threads::Threads
     WebP::webpdecoder
     ZLIB::ZLIB

--- a/engine/render/r_main.cpp
+++ b/engine/render/r_main.cpp
@@ -1984,7 +1984,7 @@ void r_renderer_c::DoScreenshot(image_c* i, int type, const char* ext)
 	time_t curTime;
 	time(&curTime);
 	auto ssPath = std::filesystem::u8path(fmt::format(CFG_DATAPATH "Screenshots/{:%m%d%y_%H%M%S}.{}",
-		fmt::localtime(curTime), ext));
+		*std::localtime(&curTime), ext));
 
 	// Make folder if it doesn't exist
 	std::error_code ec;

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "builtin",
-    "baseline": "3d72d8c930e1b6a1b2432b262c61af7d3287dcd0"
+    "baseline": "66c0373dc7fca549e5803087b9487edfe3aca0a1"
   },
   "registries": [
     {


### PR DESCRIPTION
This pull request bumps the vcpkg submodule and our vcpkg baseline to `2026.01.16`, touching up our code minimally to still build. It puts us in a better spot to do other changes in the future like adopting a newer C++ standard, upgrading the compiler, and patching our CI actions/runners.

The previous vcpkg baseline is starting to get old enough that some of the external sources it references can't be downloaded anymore. Our bundled ports for `glfw3`, `gli` and `luajit` are untouched.