### PR TITLE
Decouple DPI_AWARE flag's dual responsibilities

### DIFF
--- a/engine/render.h
+++ b/engine/render.h
@@ -107,6 +107,7 @@ public:
 	virtual int		VirtualScreenWidth() = 0;
 	virtual int		VirtualScreenHeight() = 0;
 	virtual float	VirtualScreenScaleFactor() = 0;
+	virtual float	APICoordScale() = 0;
 	virtual void	SetDpiScaleOverridePercent(int percent) = 0;
 	virtual int		DpiScaleOverridePercent() const = 0;
 	virtual int		VirtualMap(int properValue) = 0;

--- a/engine/render/r_main.cpp
+++ b/engine/render/r_main.cpp
@@ -1864,23 +1864,18 @@ int r_renderer_c::DrawStringCursorIndex(int height, int font, const char* str, i
 // ==============
 
 int r_renderer_c::VirtualScreenWidth() {
-	int const properWidth = apiDpiAware ? sys->video->vid.fbSize[0] : sys->video->vid.size[0];
-	return VirtualMap(properWidth);
+	return sys->video->vid.fbSize[0];
 }
 
 int r_renderer_c::VirtualScreenHeight() {
-	int const properHeight = apiDpiAware ? sys->video->vid.fbSize[1] : sys->video->vid.size[1];
-	return VirtualMap(properHeight);
+	return sys->video->vid.fbSize[1];
 }
 
 float r_renderer_c::VirtualScreenScaleFactor() {
-	if (apiDpiAware) {
-		if (dpiScaleOverridePercent > 0) {
-			return dpiScaleOverridePercent / 100.0f;
-		}
-		return sys->video->vid.dpiScale;
+	if (dpiScaleOverridePercent > 0) {
+		return dpiScaleOverridePercent / 100.0f;
 	}
-	return 1.0f;
+	return sys->video->vid.dpiScale;
 }
 
 void r_renderer_c::SetDpiScaleOverridePercent(int percent) {
@@ -1895,14 +1890,21 @@ int r_renderer_c::VirtualMap(int properValue) {
 	if (apiDpiAware) {
 		return properValue;
 	}
-	return static_cast<int>(properValue / sys->video->vid.dpiScale);
+	return static_cast<int>(properValue / VirtualScreenScaleFactor());
 }
 
 int r_renderer_c::VirtualUnmap(int mappedValue) {
 	if (apiDpiAware) {
 		return mappedValue;
 	}
-	return static_cast<int>(mappedValue * sys->video->vid.dpiScale);
+	return static_cast<int>(mappedValue * VirtualScreenScaleFactor());
+}
+
+float r_renderer_c::APICoordScale() {
+	if (apiDpiAware) {
+		return 1.0f;
+	}
+	return VirtualScreenScaleFactor();
 }
 
 // =====

--- a/engine/render/r_main.h
+++ b/engine/render/r_main.h
@@ -100,6 +100,7 @@ public:
 	int		VirtualScreenWidth();
 	int		VirtualScreenHeight();
 	float	VirtualScreenScaleFactor();
+	float	APICoordScale();
 	void	SetDpiScaleOverridePercent(int percent);
 	int		DpiScaleOverridePercent() const;
 	int		VirtualMap(int properValue);

--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -722,8 +722,8 @@ static int l_RenderInit(lua_State* L)
 static int l_GetScreenSize(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
-	lua_pushinteger(L, ui->renderer->VirtualScreenWidth());
-	lua_pushinteger(L, ui->renderer->VirtualScreenHeight());
+	lua_pushinteger(L, ui->renderer->VirtualMap(ui->renderer->VirtualScreenWidth()));
+	lua_pushinteger(L, ui->renderer->VirtualMap(ui->renderer->VirtualScreenHeight()));
 	return 2;
 }
 
@@ -793,7 +793,7 @@ static int l_SetViewport(lua_State* L)
 	ui->LAssert(L, ui->renderer != NULL, "Renderer is not initialised");
 	ui->LAssert(L, ui->renderEnable, "SetViewport() called outside of OnFrame");
 	int n = lua_gettop(L);
-	const float dpiScale = ui->renderer->VirtualScreenScaleFactor();
+	const float dpiScale = ui->renderer->APICoordScale();
 	if (n) {
 		ui->LAssert(L, n >= 4, "Usage: SetViewport([x, y, width, height])");
 		for (int i = 1; i <= 4; i++) {
@@ -935,7 +935,7 @@ static int l_DrawImage(lua_State* L)
 	}
 
 	if (af & AF_XY) {
-		const float dpiScale = ui->renderer->VirtualScreenScaleFactor();
+		const float dpiScale = ui->renderer->APICoordScale();
 		for (int i = k; i < k + 4; i++) {
 			int isNum;
 			lua_Number val = lua_tonumberx(L, i, &isNum);
@@ -1054,7 +1054,7 @@ static int l_DrawImageQuad(lua_State* L)
 	}
 
 	if (af & AF_XY) {
-		const float dpiScale = ui->renderer->VirtualScreenScaleFactor();
+		const float dpiScale = ui->renderer->APICoordScale();
 		for (int i = k; i < k + 8; i++) {
 			int isNum;
 			lua_Number val = lua_tonumberx(L, i, &isNum);
@@ -1144,7 +1144,7 @@ static int l_DrawString(lua_State* L)
 	ui->LAssert(L, lua_isstring(L, 6), "DrawString() argument 6: expected string, got %s", luaL_typename(L, 6));
 	static const char* alignMap[6] = { "LEFT", "CENTER", "RIGHT", "CENTER_X", "RIGHT_X", NULL };
 	static const char* fontMap[8] = { "FIXED", "VAR", "VAR BOLD", "FONTIN SC", "FONTIN SC ITALIC", "FONTIN", "FONTIN ITALIC", NULL };
-	const float dpiScale = ui->renderer->VirtualScreenScaleFactor();
+	const float dpiScale = ui->renderer->APICoordScale();
 	const float left = lua_tonumber(L, 1) * dpiScale;
 	const float top = lua_tonumber(L, 2) * dpiScale;
 	const lua_Number logicalHeight = lua_tonumber(L, 4);
@@ -1186,7 +1186,7 @@ static int l_DrawStringWidth(lua_State* L)
 	ui->LAssert(L, lua_isstring(L, 2), "DrawStringWidth() argument 2: expected string, got %s", luaL_typename(L, 2));
 	ui->LAssert(L, lua_isstring(L, 3), "DrawStringWidth() argument 3: expected string, got %s", luaL_typename(L, 3));
 	static const char* fontMap[8] = { "FIXED", "VAR", "VAR BOLD", "FONTIN SC", "FONTIN SC ITALIC", "FONTIN", "FONTIN ITALIC", NULL };
-	const float dpiScale = ui->renderer->VirtualScreenScaleFactor();
+	const float dpiScale = ui->renderer->APICoordScale();
 	const lua_Number logicalHeight = lua_tonumber(L, 1);
 	int scaledHeight = static_cast<int>(std::lround(logicalHeight * dpiScale));
 	if (scaledHeight <= 1) {
@@ -1208,7 +1208,7 @@ static int l_DrawStringCursorIndex(lua_State* L)
 	ui_main_c* ui = GetUIPtr(L);
 	ui->LAssert(L, ui->renderer != NULL, "Renderer is not initialised");
 	int n = lua_gettop(L);
-	const float dpiScale = ui->renderer->VirtualScreenScaleFactor();
+	const float dpiScale = ui->renderer->APICoordScale();
 	ui->LAssert(L, n >= 5, "Usage: DrawStringCursorIndex(height, font, text, cursorX, cursorY)");
 	ui->LAssert(L, lua_isnumber(L, 1), "DrawStringCursorIndex() argument 1: expected number, got %s", luaL_typename(L, 1));
 	ui->LAssert(L, lua_isstring(L, 2), "DrawStringCursorIndex() argument 2: expected string, got %s", luaL_typename(L, 2));
@@ -1534,9 +1534,8 @@ static int l_SetWindowTitle(lua_State* L)
 static int l_GetCursorPos(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
-	const float dpiScale = ui->renderer->VirtualScreenScaleFactor();
-	lua_pushinteger(L, (lua_Integer)std::lround(ui->renderer->VirtualMap(ui->cursorX) / dpiScale));
-	lua_pushinteger(L, (lua_Integer)std::lround(ui->renderer->VirtualMap(ui->cursorY) / dpiScale));
+	lua_pushinteger(L, (lua_Integer)std::lround(ui->renderer->VirtualMap(ui->cursorX)));
+	lua_pushinteger(L, (lua_Integer)std::lround(ui->renderer->VirtualMap(ui->cursorY)));
 	return 2;
 }
 
@@ -1544,7 +1543,7 @@ static int l_SetCursorPos(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
 	int n = lua_gettop(L);
-	const float dpiScale = ui->renderer->VirtualScreenScaleFactor();
+	const float dpiScale = ui->renderer->APICoordScale();
 	ui->LAssert(L, n >= 2, "Usage: SetCursorPos(x, y)");
 	ui->LAssert(L, lua_isnumber(L, 1), "SetCursorPos() argument 1: expected number, got %s", luaL_typename(L, 1));
 	ui->LAssert(L, lua_isnumber(L, 2), "SetCursorPos() argument 2: expected number, got %s", luaL_typename(L, 2));


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding-SimpleGraphic/issues/93
### Problem
The `DPI_AWARE` flag controlled two independent things simultaneously:
1. **Rendering pipeline** — whether API functions scale coordinates by `dpiScale` (with RTT at `fbSize`) or not (with RTT at virtual size and blit upscaling)
2. **API contract** — whether `GetScreenSize`/`GetCursorPos` return physical or virtual units
This meant you couldn't disable the flag (to get virtual units in the API) without also losing the scaling behavior entirely. Additionally, `SetDPIScaleOverridePercent` was ignored without the flag, and `GetScreenScale` returned `1.0` — hiding the true scale factor from Lua.
### Solution
Decoupled the two concerns by making the rendering pipeline always use the "physical RTT" path (RTT at `fbSize`, API pre-scales coordinates, 1:1 blit), regardless of the flag. The flag now solely controls the API unit contract.
### Changes
**`engine/render.h` / `engine/render/r_main.h`** — Added `APICoordScale()` method.
**`engine/render/r_main.cpp`** (4 functions rewritten, 1 added):
- `VirtualScreenWidth/Height()` — Always return `fbSize` (RTT always at full resolution)
- `VirtualScreenScaleFactor()` — Always returns the effective scale (removed `apiDpiAware` guard + `return 1.0f` fallback)
- `VirtualMap/VirtualUnmap()` — Use `VirtualScreenScaleFactor()` instead of raw `vid.dpiScale`, so the override is always respected
- New `APICoordScale()` — Returns `1.0f` when `apiDpiAware` (coordinates already physical), otherwise `VirtualScreenScaleFactor()` (convert virtual -> physical)
**`ui_api.cpp`** (9 API functions updated):
- `l_GetScreenSize` — Applies `VirtualMap` to convert `fbSize` -> virtual when not DPI_AWARE
- `l_SetViewport`, `l_DrawImage`, `l_DrawImageQuad`, `l_DrawString`, `l_DrawStringWidth`, `l_DrawStringCursorIndex`, `l_SetCursorPos` — Changed from `VirtualScreenScaleFactor()` to `APICoordScale()`
- `l_GetCursorPos` — Removed redundant double-division by `dpiScale` after `VirtualMap`
### Behaviour Matrix
| Scenario | Before (flag on) | Before (flag off) | After (flag off) | After (flag on) |
|---|---|---|---|---|
| `GetScreenSize` | physical (fbSize) | virtual (broken: 1.0 scale) | **virtual** OK | physical OK |
| `GetScreenScale` | dpiScale | 1.0 (wrong) | **dpiScale** OK | dpiScale OK |
| `SetDPIScaleOverridePercent` | works | ignored | **works** OK | works OK |
| Visual scaling | pre-scale coords | RTT blit upscale | **pre-scale coords** OK | pre-scale coords OK |

No Lua-side API consumers need changes beyond removing the flag from `RenderInit()` and any workarounds for the old inconsistent behaviour.

***Code and PR Co-Written by DeepSeek***