### PR TITLE
Add Gzip support to Inflate/Deflate

### DIFF
--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -1609,10 +1609,13 @@ static int l_Deflate(lua_State* L)
 	int n = lua_gettop(L);
 	ui->LAssert(L, n >= 1, "Usage: Deflate(string)");
 	ui->LAssert(L, lua_isstring(L, 1), "Deflate() argument 1: expected string, got %s", luaL_typename(L, 1));
+	ui->LAssert(L, lua_isboolean(L, 2) || lua_isnil(L, 2) || lua_isnone(L, 2), "Deflate() argument 2: expected boolean or nil, got %s", luaL_typename(L, 2));
+	bool isGzip = lua_toboolean(L, 2);
 	z_stream_s z;
 	z.zalloc = NULL;
 	z.zfree = NULL;
-	deflateInit(&z, 9);
+	// Adding 16 enables Gzip headers instead of ZLib headers
+	deflateInit2(&z, 9, Z_DEFLATED, MAX_WBITS + (isGzip ? 16 : 0), 8, Z_DEFAULT_STRATEGY);
 	size_t inLen;
 	byte* in = (byte*)lua_tolstring(L, 1, &inLen);
 	// Prevent deflation of input data larger than 128 MiB.
@@ -1666,7 +1669,8 @@ static int l_Inflate(lua_State* L)
 	z.zfree = NULL;
 	z.next_out = out.data();
 	z.avail_out = outSz;
-	inflateInit(&z);
+	// Adding 32 enables automatic detection of headers
+	inflateInit2(&z, MAX_WBITS + 32);
 	int err;
 	while ((err = inflate(&z, Z_NO_FLUSH)) == Z_OK) {
 		// Output buffer filled, try to embiggen it.

--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -1615,7 +1615,7 @@ static int l_Deflate(lua_State* L)
 	z.zalloc = NULL;
 	z.zfree = NULL;
 	// Adding 16 enables Gzip headers instead of ZLib headers
-	deflateInit2(&z, 9, Z_DEFLATED, MAX_WBITS + (isGzip ? 16 : 0), 8, Z_DEFAULT_STRATEGY);
+	deflateInit2(&z, Z_BEST_COMPRESSION, Z_DEFLATED, MAX_WBITS + (isGzip ? 16 : 0), 8, Z_DEFAULT_STRATEGY);
 	size_t inLen;
 	byte* in = (byte*)lua_tolstring(L, 1, &inLen);
 	// Prevent deflation of input data larger than 128 MiB.

--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -84,7 +84,9 @@
 ** Copy("<string>")
 ** string = Paste()
 ** compressed = Deflate(uncompressed)
+** compressedGzip = Deflate(uncompressed, true)
 ** uncompressed = Inflate(compressed)
+** uncompressedGzip = Inflate(compressedGzip)
 ** msec = GetTime()
 ** path[, pathACP[, err]] = GetScriptPath()
 ** path[, pathACP[, err]] = GetRuntimePath()
@@ -1607,7 +1609,7 @@ static int l_Deflate(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
 	int n = lua_gettop(L);
-	ui->LAssert(L, n >= 1, "Usage: Deflate(string)");
+	ui->LAssert(L, n >= 1, "Usage: Deflate(string, [isGzip])");
 	ui->LAssert(L, lua_isstring(L, 1), "Deflate() argument 1: expected string, got %s", luaL_typename(L, 1));
 	ui->LAssert(L, lua_isboolean(L, 2) || lua_isnil(L, 2) || lua_isnone(L, 2), "Deflate() argument 2: expected boolean or nil, got %s", luaL_typename(L, 2));
 	bool isGzip = lua_toboolean(L, 2);


### PR DESCRIPTION
This adds a boolean toggle to Deflate to set the window bits to output Gzip headers. For inflate, this sets the window bits to detect headers automatically. Raw DEFLATE is still unsupported.

@meehl