### PR TITLE
feat: bump language version to C++23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(SimpleGraphic C CXX)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 23)
 
 if (APPLE)
     enable_language(OBJCXX)

--- a/engine/core/core_config.cpp
+++ b/engine/core/core_config.cpp
@@ -159,7 +159,8 @@ bool core_config_c::LoadConfig(std::filesystem::path const& cfgName)
 	auto fileName = cfgName;
 	fileName.replace_extension(".cfg");
 
-	sys->con->Print(fmt::format("Executing {}\n", fileName.generic_u8string()).c_str());
+	const auto fileNameU8 = fileName.generic_u8string();
+	sys->con->Print(fmt::format("Executing {}\n", std::string_view((const char*)fileNameU8.data(), fileNameU8.size())).c_str());
 
 	// Read the config file
 	fileInputStream_c f;
@@ -203,7 +204,8 @@ bool core_config_c::SaveConfig(std::filesystem::path const& cfgName)
 	auto fileName = cfgName;
 	fileName.replace_extension(".cfg");
 
-	sys->con->Print(fmt::format("Saving {}\n", fileName.generic_u8string()).c_str());
+	const auto fileNameU8 = fileName.generic_u8string();
+	sys->con->Print(fmt::format("Saving {}\n", std::string_view((const char*)fileNameU8.data(), fileNameU8.size())).c_str());
 
 	// Open the config file
 	fileOutputStream_c f;

--- a/engine/render/r_main.cpp
+++ b/engine/render/r_main.cpp
@@ -816,7 +816,7 @@ void r_renderer_c::Init(r_featureFlag_e features)
 			glShaderSource(fs, 1, &fragSourcePtr, nullptr);
 		}
 		catch (std::exception& e) {
-			sys->Error(u8"Failed to format fragment shader:\n%s", e.what());
+			sys->Error("Failed to format fragment shader:\n%s", e.what());
 		}
 		glCompileShader(fs);
 		if (!GetShaderCompileSuccess(fs)) {
@@ -1770,7 +1770,8 @@ void r_renderer_c::DoScreenshot(image_c* i, int type, const char* ext)
 		sys->con->Print("Couldn't write screenshot!\n");
 		return;
 	}
-	sys->con->Print(fmt::format("Wrote screenshot to {}\n", ssPath.generic_u8string()).c_str());
+	const auto ssPathU8 = ssPath.generic_u8string();
+	sys->con->Print(fmt::format("Wrote screenshot to {}\n", std::string_view((const char*)ssPathU8.data(), ssPathU8.size())).c_str());
 }
 
 r_renderer_c::RenderTarget& r_renderer_c::GetDrawRenderTarget()

--- a/engine/system/win/sys_main.cpp
+++ b/engine/system/win/sys_main.cpp
@@ -140,14 +140,14 @@ std::optional<std::string> BuildGlobPattern(std::filesystem::path const& glob)
 {
 	using namespace std::literals::string_view_literals;
 	auto globStr = glob.generic_u8string();
-	auto globView = std::string_view(globStr);
+	auto globView = std::string_view((const char*)globStr.data(), globStr.size());
 
 	// Deal with traditional "everything" wildcards.
 	if (globView == "*" || globView == "*.*") {
 		return {};
 	}
 
-	auto u32Str = IndexUTF8ToUTF32(globStr);
+	auto u32Str = IndexUTF8ToUTF32(globView);
 	auto& offsets = u32Str.sourceCodeUnitOffsets;
 
 	fmt::memory_buffer buf;
@@ -200,8 +200,8 @@ bool GlobMatch(std::optional<std::string> const& globPattern, std::filesystem::p
 	reOpts.set_case_sensitive(false);
 	RE2 reGlob{globPattern.value(), reOpts};
 
-	auto fileStr = file.generic_u8string();
-	return RE2::FullMatch(fileStr, reGlob);
+	auto fileU8 = file.generic_u8string();
+	return RE2::FullMatch(std::string_view((const char*)fileU8.data(), fileU8.size()), reGlob);
 }
 
 bool find_c::FindFirst(std::filesystem::path const&& fileSpec)

--- a/engine/system/win/sys_video.cpp
+++ b/engine/system/win/sys_video.cpp
@@ -318,6 +318,7 @@ bool ShouldIgnoreDpiScale() {
 	struct ScopedRegKey {
 		HKEY key{};
 
+		ScopedRegKey() = default;
 		ScopedRegKey& operator = (ScopedRegKey const&) = delete;
 		ScopedRegKey(ScopedRegKey const&) = delete;
 		~ScopedRegKey() {

--- a/ui_api.cpp
+++ b/ui_api.cpp
@@ -429,7 +429,8 @@ SG_LUA_CPP_FUN_BEGIN(imgHandleLoad)
 		}
 	}
 	// TODO(LV): should we use u8path throughout here, to support any callers that use paths outside of working directory?
-	imgHandle->hnd = ui->renderer->RegisterShader(fileName.generic_u8string(), flags);
+	auto shaderName = fileName.generic_u8string();
+	imgHandle->hnd = ui->renderer->RegisterShader(std::string_view((const char*)shaderName.data(), shaderName.size()), flags);
 	return 0;
 }
 SG_LUA_CPP_FUN_END()
@@ -1351,7 +1352,7 @@ static int l_searchHandleGetFileName(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
 	searchHandle_s* searchHandle = GetSearchHandle(L, ui, "GetFileName", true);
-	lua_pushstring(L, searchHandle->find->fileName.generic_u8string().c_str());
+	lua_pushstring(L, (const char*)searchHandle->find->fileName.generic_u8string().c_str());
 	return 1;
 }
 
@@ -1655,7 +1656,7 @@ static int l_GetTime(lua_State* L)
 static int l_GetScriptPath(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
-	lua_pushstring(L, ui->scriptPath.generic_u8string().c_str());
+	lua_pushstring(L, (const char*)ui->scriptPath.generic_u8string().c_str());
 	try
 	{
 		lua_pushstring(L, ui->scriptPath.generic_string().c_str());
@@ -1672,7 +1673,7 @@ static int l_GetScriptPath(lua_State* L)
 static int l_GetRuntimePath(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
-	lua_pushstring(L, ui->sys->basePath.generic_u8string().c_str());
+	lua_pushstring(L, (const char*)ui->sys->basePath.generic_u8string().c_str());
 	try
 	{
 		lua_pushstring(L, ui->sys->basePath.generic_string().c_str());
@@ -1701,7 +1702,7 @@ static int l_GetUserPath(lua_State* L)
 		return 2;
 	}
 
-	lua_pushstring(L, userPath->generic_u8string().c_str());
+	lua_pushstring(L, (const char*)userPath->generic_u8string().c_str());
 	try
 	{
 		lua_pushstring(L, userPath->generic_string().c_str());
@@ -1781,7 +1782,7 @@ SG_LUA_CPP_FUN_END()
 static int l_GetWorkDir(lua_State* L)
 {
 	ui_main_c* ui = GetUIPtr(L);
-	lua_pushstring(L, ui->scriptWorkDir.generic_u8string().c_str());
+	lua_pushstring(L, (const char*)ui->scriptWorkDir.generic_u8string().c_str());
 	return 1;
 }
 
@@ -1862,7 +1863,7 @@ SG_LUA_CPP_FUN_BEGIN(LoadModule)
 
 	ui->sys->SetWorkDir(ui->scriptPath);
 	auto fileStr = fileName.generic_u8string();
-	int err = luaL_loadfile(L, fileStr.c_str());
+	int err = luaL_loadfile(L, (const char*)fileStr.c_str());
 	ui->sys->SetWorkDir(ui->scriptWorkDir);
 	ui->LExpect(L, err == 0, "LoadModule() error loading '%s' (%d):\n%s", fileStr.c_str(), err, lua_tostring(L, -1));
 	lua_replace(L, 1);	// Replace module name with module main chunk
@@ -1884,7 +1885,7 @@ SG_LUA_CPP_FUN_BEGIN(PLoadModule)
 	}
 
 	ui->sys->SetWorkDir(ui->scriptPath);
-	int err = luaL_loadfile(L, fileName.generic_u8string().c_str());
+	int err = luaL_loadfile(L, (const char*)fileName.generic_u8string().c_str());
 	ui->sys->SetWorkDir(ui->scriptWorkDir);
 	if (err) {
 		return 1;

--- a/ui_main.cpp
+++ b/ui_main.cpp
@@ -178,7 +178,7 @@ void ui_main_c::DoError(const char* msg, const char* error)
 {
 	auto scriptStr = scriptName.generic_u8string();
 	char* errText = AllocStringLen(strlen(msg) + scriptStr.size() + strlen(error) + 30);
-	sprintf(errText, "--- SCRIPT ERROR ---\n%s '%s':\n%s\n", msg, scriptStr.c_str(), error);
+	sprintf(errText, "--- SCRIPT ERROR ---\n%s '%s':\n%s\n", msg, (const char*)scriptStr.c_str(), error);
 	sys->Exit(errText);
 	FreeString(errText);
 	didExit = true;
@@ -286,7 +286,7 @@ void ui_main_c::ScriptInit()
 	if (!scriptPath.empty()) {
 		sys->con->Printf("Script working directory: %s\n", scriptWorkDir.generic_u8string().c_str());
 	}
-	sys->video->SetTitle(scriptName.generic_u8string().c_str());
+	sys->video->SetTitle((const char*)scriptName.generic_u8string().c_str());
 
 	restartFlag = false;
 	didExit = false;
@@ -329,7 +329,7 @@ void ui_main_c::ScriptInit()
 	
 	// Load the script file
 	sys->SetWorkDir(scriptWorkDir);
- 	err = luaL_loadfile(L, scriptName.filename().generic_u8string().c_str());
+ 	err = luaL_loadfile(L, (const char*)scriptName.filename().generic_u8string().c_str());
 	if (err) {
 		DoError("Error loading", lua_tostring(L, -1));
 		return;


### PR DESCRIPTION
This advances the C++ version from C++17 to C++23, most of the immediate fallout is from UTF-8 strings in filesystem code.

This change keeps the impact minimal by casting at the boundaries rather than changing internal string representations to u8string and char8_t, something that might be desirable down the line.